### PR TITLE
fix: support erlang module aliases for rename remote function

### DIFF
--- a/apps/engine/lib/engine/code_action/handlers/replace_remote_function.ex
+++ b/apps/engine/lib/engine/code_action/handlers/replace_remote_function.ex
@@ -1,6 +1,8 @@
 defmodule Engine.CodeAction.Handlers.ReplaceRemoteFunction do
   @behaviour Engine.CodeAction.Handler
 
+  alias ElixirSense.Core.Metadata
+  alias ElixirSense.Core.Parser
   alias Engine.CodeAction
   alias Engine.Modules
   alias Forge.Ast
@@ -39,7 +41,7 @@ defmodule Engine.CodeAction.Handlers.ReplaceRemoteFunction do
     suggestions
     |> Enum.reduce([], fn suggestion, acc ->
       case apply_transform(doc, line_number, module, function, suggestion) do
-        {:ok, edits} ->
+        {:ok, [_ | _] = edits} ->
           changes = Changes.new(doc, edits)
 
           code_action =
@@ -51,6 +53,9 @@ defmodule Engine.CodeAction.Handlers.ReplaceRemoteFunction do
             )
 
           [code_action | acc]
+
+        {:ok, []} ->
+          acc
 
         :error ->
           acc
@@ -70,7 +75,16 @@ defmodule Engine.CodeAction.Handlers.ReplaceRemoteFunction do
     |> Ast.traverse_line(line_number, [], fn
       %Zipper{node: {{:., _, [{:__aliases__, _, module_alias}, ^function_atom]}, _, _}} = zipper,
       patches ->
-        case Engine.Analyzer.expand_alias(module_alias, analysis, position) do
+        if Engine.Analyzer.expand_alias(module_alias, analysis, position) == {:ok, module} or
+             alias_matches?(doc, module_alias, module, line_number) do
+          patch = Sourceror.Patch.rename_call(zipper.node, suggestion)
+          {zipper, [patch | patches]}
+        else
+          {zipper, patches}
+        end
+
+      %Zipper{node: {{:., _, [{:__MODULE__, _, _}, ^function_atom]}, _, _}} = zipper, patches ->
+        case Engine.Analyzer.current_module(analysis, position) do
           {:ok, ^module} ->
             patch = Sourceror.Patch.rename_call(zipper.node, suggestion)
             {zipper, [patch | patches]}
@@ -104,7 +118,7 @@ defmodule Engine.CodeAction.Handlers.ReplaceRemoteFunction do
     end
   end
 
-  @function_re ~r/(warning: |function )?([^\/]+)\/(.*) is undefined or private. Did you mean:.*/
+  @function_re ~r/(warning: |function )?([^\/]+)\/(\d+) is undefined or private. Did you mean:.*/
   defp extract_function(message) do
     result =
       with [[_, _, module_and_function, arity]] <- Regex.scan(@function_re, message),
@@ -135,6 +149,16 @@ defmodule Engine.CodeAction.Handlers.ReplaceRemoteFunction do
   defp alias_to_module(module_alias) do
     Module.concat(module_alias)
   end
+
+  defp alias_matches?(document, [alias] = module_alias, module, line) when is_atom(alias) do
+    position = {line, 1}
+    metadata = Parser.parse_string(Document.to_string(document), true, false, position)
+    env = Metadata.get_cursor_env(metadata, position)
+
+    {Module.concat(module_alias), module} in env.aliases
+  end
+
+  defp alias_matches?(_document, _module_alias, _module, _line), do: false
 
   @function_threshold 0.77
   @max_suggestions 5

--- a/apps/engine/test/engine/code_action/handlers/replace_remote_function_test.exs
+++ b/apps/engine/test/engine/code_action/handlers/replace_remote_function_test.exs
@@ -19,16 +19,11 @@ defmodule Engine.CodeAction.Handlers.ReplaceRemoteFunctionTest do
         * count/2
   """
 
-  def apply_code_mod(original_text, _ast, options) do
+  def code_actions(original_text, options) do
     line_number = Keyword.get(options, :line, 1)
     message_body = Keyword.get(options, :message, @default_message)
     message_prefix = Keyword.get(options, :message_prefix, "")
     message = message_prefix <> message_body
-
-    suggestion =
-      options
-      |> Keyword.get(:suggestion, :count)
-      |> Atom.to_string()
 
     :ok = Document.Store.open("file:///file.ex", original_text, 0)
     {:ok, document} = Document.Store.fetch("file:///file.ex")
@@ -41,9 +36,15 @@ defmodule Engine.CodeAction.Handlers.ReplaceRemoteFunctionTest do
 
     diagnostic = Diagnostic.new(range, message, nil)
 
+    ReplaceRemoteFunction.actions(document, range, [diagnostic])
+  end
+
+  def apply_code_mod(original_text, _ast, options) do
+    suggestion = options |> Keyword.get(:suggestion, :count) |> Atom.to_string()
+
     changes =
-      document
-      |> ReplaceRemoteFunction.actions(range, [diagnostic])
+      original_text
+      |> code_actions(options)
       |> Enum.flat_map(& &1.changes.edits)
       |> Enum.filter(fn
         %Forge.Document.Edit{text: ^suggestion} -> true
@@ -266,6 +267,59 @@ defmodule Engine.CodeAction.Handlers.ReplaceRemoteFunctionTest do
 
         assert result == "&:ets.insert/2"
       end
+    end
+  end
+
+  describe "receiver resolution" do
+    test "handles aliased Erlang modules" do
+      message = ":ets.inserd/2 is undefined or private. Did you mean: insert/2"
+      original = ~q[
+        defmodule Example do
+          alias :ets, as: Table
+          def run, do: Table.inserd(:table, {:key, :value})
+        end
+      ]t
+      expected = String.replace(original, "inserd", "insert")
+
+      assert {:ok, ^expected} = modify(original, message: message, line: 3, suggestion: :insert)
+    end
+
+    test "handles __MODULE__" do
+      original = ~q{
+        defmodule Enum do
+          def run, do: __MODULE__.counts([1, 2, 3])
+        end
+      }t
+      expected = String.replace(original, "counts", "count")
+
+      assert {:ok, ^expected} = modify(original, line: 2)
+    end
+
+    test "does not treat __MODULE__.Nested as the diagnostic module" do
+      original = ~q{
+        defmodule Other do
+          def run, do: Enum.counts([]) + __MODULE__.Nested.counts([])
+        end
+      }t
+      expected = String.replace(original, "Enum.counts", "Enum.count")
+
+      assert {:ok, ^expected} = modify(original, line: 2)
+    end
+  end
+
+  describe "invalid diagnostics" do
+    test "does not return actions without edits" do
+      actions = code_actions("other.counts([1, 2, 3])", line: 1)
+
+      assert actions == []
+    end
+
+    test "ignores a non-numeric arity" do
+      message = "Enum.counts/one is undefined or private. Did you mean: count/1"
+
+      actions = code_actions("Enum.counts([1, 2, 3])", line: 1, message: message)
+
+      assert actions == []
     end
   end
 end


### PR DESCRIPTION
Close #144 

We already have that function implemented, but there were some bugs around aliased modules in our implementation that I fixed here
