### PR TITLE
fix: relax Hex connectivity timeout

### DIFF
--- a/apps/forge/lib/forge/internet.ex
+++ b/apps/forge/lib/forge/internet.ex
@@ -4,7 +4,7 @@ defmodule Forge.Internet do
     # it seems reasonable to gate pulling dependencies on a resolution check for hex.pm.
     # Yes, it's entirely possible that the DNS server is local, and that the entry is in cache,
     # but that's an edge case, and the build will just time out anyways.
-    case :inet_res.getbyname(~c"hex.pm", :a, 250) do
+    case :inet_res.getbyname(~c"hex.pm", :a, 5_000) do
       {:ok, _} -> true
       _ -> false
     end

--- a/apps/forge/test/forge/internet_test.exs
+++ b/apps/forge/test/forge/internet_test.exs
@@ -1,0 +1,30 @@
+defmodule Forge.InternetTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Forge.Internet
+
+  test "returns true when hex.pm resolves within five seconds" do
+    patch(:inet_res, :getbyname, fn host, family, timeout ->
+      assert host == ~c"hex.pm"
+      assert family == :a
+      assert timeout == 5_000
+
+      {:ok, :hostent}
+    end)
+
+    assert Internet.connected_to_internet?()
+  end
+
+  test "returns false when hex.pm resolution fails" do
+    patch(:inet_res, :getbyname, fn host, family, timeout ->
+      assert host == ~c"hex.pm"
+      assert family == :a
+      assert timeout == 5_000
+
+      {:error, :timeout}
+    end)
+
+    refute Internet.connected_to_internet?()
+  end
+end


### PR DESCRIPTION
Increase the `hex.pm` DNS lookup timeout in `Forge.Internet` from 250 ms to a bounded multi-second value (5 seconds), retaining the existing boolean contract and avoiding changes to the two production consumers in `Engine.Build.Project` and `Engine.Mix`. Expert gates Hex and dependency installation on `Forge.Internet.connected_to_internet?/0`, which resolves `hex.pm` with a 250 ms timeout.

When `hex.pm` resolves successfully, `connected_to_internet?/0` calls `:inet_res.getbyname/3` with the 5-second bound and returns `true`, allowing the existing dependency setup path to run; When DNS returns an error such as `:timeout` or `:nxdomain`, `connected_to_internet?/0` returns `false` without raising, preserving the existing offline warning behavior.

Fixes #538
