### PR TITLE
feat: add implementations support

### DIFF
--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -48,6 +48,10 @@ defmodule Engine do
 
   defdelegate definition(document, position), to: CodeIntelligence.Definition
 
+  defdelegate implementation(document, position),
+    to: CodeIntelligence.Implementations,
+    as: :implementations
+
   defdelegate hover(document, position), to: CodeIntelligence.Hover
 
   defdelegate references(analysis, position, include_definitions?),

--- a/apps/engine/lib/engine/code_intelligence/implementations.ex
+++ b/apps/engine/lib/engine/code_intelligence/implementations.ex
@@ -1,0 +1,52 @@
+defmodule Engine.CodeIntelligence.Implementations do
+  alias ElixirSense.Providers.Location, as: ElixirSenseLocation
+  alias Forge.Document
+  alias Forge.Document.Location
+  alias Forge.Document.Position
+  alias Forge.Document.Range
+
+  @spec implementations(Document.t(), Position.t()) ::
+          {:ok, [Location.t()]} | {:error, String.t()}
+  def implementations(%Document{} = document, %Position{} = position) do
+    document
+    |> Document.to_string()
+    |> ElixirSense.implementations(position.line, position.character)
+    |> Enum.reduce_while({:ok, []}, fn location, {:ok, locations} ->
+      case from_elixir_sense_location(location, document) do
+        {:ok, location} -> {:cont, {:ok, [location | locations]}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, locations} -> {:ok, Enum.reverse(locations)}
+      error -> error
+    end
+  end
+
+  defp from_elixir_sense_location(%ElixirSenseLocation{} = location, current_document) do
+    %{file: file, line: line, column: column, end_line: end_line, end_column: end_column} =
+      location
+
+    case location_document(file, current_document) do
+      {:ok, document} ->
+        range =
+          Range.new(
+            Position.new(document, line, column),
+            Position.new(document, end_line, end_column)
+          )
+
+        {:ok, Location.new(range, document)}
+
+      _ ->
+        {:error, "Could not open implementation source file: #{inspect(file)}"}
+    end
+  end
+
+  defp location_document(nil, %Document{} = document), do: {:ok, document}
+
+  defp location_document(file, _current_document) do
+    file
+    |> Document.Path.ensure_uri()
+    |> Document.Store.open_temporary()
+  end
+end

--- a/apps/engine/lib/engine/code_intelligence/implementations.ex
+++ b/apps/engine/lib/engine/code_intelligence/implementations.ex
@@ -1,5 +1,6 @@
 defmodule Engine.CodeIntelligence.Implementations do
   alias ElixirSense.Providers.Location, as: ElixirSenseLocation
+  alias Forge.Ast
   alias Forge.Document
   alias Forge.Document.Location
   alias Forge.Document.Position
@@ -35,10 +36,28 @@ defmodule Engine.CodeIntelligence.Implementations do
             Position.new(document, end_line, end_column)
           )
 
+        range = normalize_range(range, document)
+
         {:ok, Location.new(range, document)}
 
       _ ->
         {:error, "Could not open implementation source file: #{inspect(file)}"}
+    end
+  end
+
+  # NOTE(doorgan): In Elixir 1.16, ElixirSense returns implementation locations
+  # where the start position is the same as the end position, producing empty
+  # ranges.
+  defp normalize_range(range, document) do
+    if Version.match?(System.version(), "~> 1.16.0") and range.start == range.end do
+      with {:ok, zipper} <- Ast.zipper_at(document, range.start),
+           {:ok, range} <- Ast.Range.fetch(zipper.node, document) do
+        range
+      else
+        _ -> range
+      end
+    else
+      range
     end
   end
 

--- a/apps/engine/test/engine/code_intelligence/implementations_test.exs
+++ b/apps/engine/test/engine/code_intelligence/implementations_test.exs
@@ -1,0 +1,249 @@
+defmodule Engine.CodeIntelligence.ImplementationsTest do
+  use ExUnit.Case, async: false
+
+  import Forge.Test.CodeSigil
+  import Forge.Test.CursorSupport
+  import Forge.Test.RangeSupport
+
+  alias Engine.CodeIntelligence.Implementations
+  alias Forge.Document
+
+  defmodule Behaviour do
+    @callback run(term()) :: term()
+  end
+
+  defmodule BehaviourImplementation do
+    @behaviour Behaviour
+
+    @impl true
+    def run(value), do: value
+  end
+
+  defprotocol Renderable do
+    def render(value)
+  end
+
+  defimpl Renderable, for: List do
+    def render(value), do: value
+  end
+
+  defmodule DelegateTarget do
+    def original(value), do: value
+    def with_default(value, _option), do: value
+  end
+
+  setup_all do
+    start_supervised!(Document.Store)
+    :ok
+  end
+
+  test "returns no implementations for unsupported contexts" do
+    for source <- [
+          "|",
+          "__MOD|ULE__",
+          "Eli|xir",
+          "DoesNotExist|",
+          "String.up|case(\"value\")",
+          ":ets.ne|w(:table, [])"
+        ] do
+      assert {:ok, []} = implementations(source), source
+    end
+  end
+
+  test "finds behaviour callback implementations" do
+    source = "Engine.CodeIntelligence.ImplementationsTest.Behaviour.ru|n(:value)"
+
+    assert {:ok, [location]} = implementations(source)
+    assert decorate(location.document, location.range) == "    «def run(value), do: value»"
+  end
+
+  test "finds behaviour modules and callbacks defined in the current buffer" do
+    sources = [
+      {~q"""
+         defmodule BufferBehav|iour do
+           @callback run(term()) :: term()
+         end
+
+         defmodule BufferBehaviourImplementation do
+           @behaviour BufferBehaviour
+           def run(value), do: value
+         end
+       """,
+       "«defmodule BufferBehaviourImplementation do\n  @behaviour BufferBehaviour\n  def run(value), do: value\nend»"},
+      {~q"""
+         defmodule BufferBehaviour do
+           @callback run(term()) :: term()
+         end
+
+         defmodule BufferBehaviourImplementation do
+           @behaviour BufferBehaviour
+           def run(value), do: value
+         end
+
+         BufferBehaviour.ru|n(:value)
+       """, "  «def run(value), do: value»"}
+    ]
+
+    for {source, expected} <- sources do
+      assert {:ok, [location]} = implementations(source)
+      assert decorate(location.document, location.range) == expected
+    end
+  end
+
+  test "finds protocol modules and functions defined in the current buffer" do
+    sources = [
+      {~q"""
+         defprotocol BufferProto|col do
+           def render(value)
+         end
+
+         defimpl BufferProtocol, for: List do
+           def render(value), do: value
+         end
+       """, "«defimpl BufferProtocol, for: List do\n  def render(value), do: value\nend»"},
+      {~q"""
+         defprotocol BufferProtocol do
+           def render(value)
+         end
+
+         defimpl BufferProtocol, for: List do
+           def render(value), do: value
+         end
+
+         BufferProtocol.ren|der([])
+       """, "  «def render(value), do: value»"}
+    ]
+
+    for {source, expected} <- sources do
+      assert {:ok, [location]} = implementations(source)
+      assert decorate(location.document, location.range) == expected
+    end
+  end
+
+  test "finds protocol functions through aliases and module attributes" do
+    for source <- [
+          ~q"""
+            alias Engine.CodeIntelligence.ImplementationsTest.Renderable, as: R
+            R.ren|der([])
+          """,
+          ~q"""
+            defmodule Caller do
+              @protocol Engine.CodeIntelligence.ImplementationsTest.Renderable
+              @protocol.ren|der([])
+            end
+          """
+        ] do
+      assert {:ok, [location]} = implementations(source)
+
+      assert decorate(location.document, location.range) ==
+               "    «def render(value), do: value»"
+    end
+  end
+
+  test "finds protocol functions from specs and implementation functions" do
+    sources = [
+      ~q"""
+        defprotocol SpecProtocol do
+          @spec ren|der(t()) :: term()
+          def render(value)
+        end
+
+        defimpl SpecProtocol, for: Atom do
+          def render(value), do: value
+        end
+      """,
+      ~q"""
+        defimpl Engine.CodeIntelligence.ImplementationsTest.Renderable, for: Atom do
+          def ren|der(value), do: value
+        end
+      """
+    ]
+
+    for {source, expected} <-
+          Enum.zip(sources, [
+            "  «def render(value), do: value»",
+            "    «def render(value), do: value»"
+          ]) do
+      assert {:ok, locations} = implementations(source)
+
+      assert Enum.any?(locations, fn location ->
+               decorate(location.document, location.range) == expected
+             end)
+    end
+  end
+
+  test "handles incomplete protocol calls and rejects invalid arities" do
+    assert {:ok, [location]} =
+             implementations("Engine.CodeIntelligence.ImplementationsTest.Renderable.ren|der(")
+
+    assert decorate(location.document, location.range) ==
+             "    «def render(value), do: value»"
+
+    assert {:ok, []} =
+             implementations(
+               "Engine.CodeIntelligence.ImplementationsTest.Renderable.ren|der(:one, "
+             )
+  end
+
+  test "follows renamed delegates and delegates with default arguments" do
+    sources = [
+      {~q"""
+         defmodule Delegate do
+           defdelegate forw|arded(value),
+             to: Engine.CodeIntelligence.ImplementationsTest.DelegateTarget,
+             as: :original
+         end
+       """, "    «def original(value), do: value»"},
+      {~q"""
+         defmodule Delegate do
+           defdelegate with_de|fault(value, option \\ :default),
+             to: Engine.CodeIntelligence.ImplementationsTest.DelegateTarget,
+             as: :with_default
+         end
+       """, "    «def with_default(value, _option), do: value»"}
+    ]
+
+    for {source, expected} <- sources do
+      assert {:ok, [location]} = implementations(source)
+      assert decorate(location.document, location.range) == expected
+    end
+  end
+
+  test "follows delegates defined in the current buffer" do
+    source = ~q"""
+      defmodule BufferDelegateTarget do
+        def original(value), do: value
+      end
+
+      defmodule BufferDelegate do
+        defdelegate forwarded(value), to: BufferDelegateTarget, as: :original
+      end
+
+      BufferDelegate.for|warded(:value)
+    """
+
+    assert {:ok, [location]} = implementations(source)
+
+    assert decorate(location.document, location.range) ==
+             "  «def original(value), do: value»"
+  end
+
+  test "does not recurse forever through recursive delegates" do
+    source = ~q"""
+      defmodule RecursiveDelegate do
+        defdelegate forw|arded(value), to: RecursiveDelegate
+      end
+    """
+
+    assert {:ok, []} = implementations(source)
+  end
+
+  defp implementations(source) do
+    {position, source} = pop_cursor(source)
+    uri = "file:///implementation_subject_#{System.unique_integer([:positive])}.ex"
+    :ok = Document.Store.open(uri, source, 1)
+    {:ok, document} = Document.Store.fetch(uri)
+
+    Implementations.implementations(document, position)
+  end
+end

--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -545,6 +545,9 @@ defmodule Expert do
       %Requests.TextDocumentDefinition{} ->
         {:ok, Handlers.GoToDefinition}
 
+      %Requests.TextDocumentImplementation{} ->
+        {:ok, Handlers.GoToImplementation}
+
       %Requests.TextDocumentHover{} ->
         {:ok, Handlers.Hover}
 

--- a/apps/expert/lib/expert/engine_api.ex
+++ b/apps/expert/lib/expert/engine_api.ex
@@ -97,6 +97,10 @@ defmodule Expert.EngineApi do
     call(project, Engine, :definition, [document, position])
   end
 
+  def implementation(%Project{} = project, %Document{} = document, %Position{} = position) do
+    call(project, Engine, :implementation, [document, position])
+  end
+
   def hover(%Project{} = project, %Document{} = document, %Position{} = position) do
     call(project, Engine, :hover, [document, position])
   end

--- a/apps/expert/lib/expert/provider/handlers/go_to_implementation.ex
+++ b/apps/expert/lib/expert/provider/handlers/go_to_implementation.ex
@@ -1,0 +1,25 @@
+defmodule Expert.Provider.Handlers.GoToImplementation do
+  @behaviour Expert.Provider.Handler
+
+  alias Expert.Document.Context
+  alias Expert.EngineApi
+  alias GenLSP.Requests
+  alias GenLSP.Structures
+
+  require Logger
+
+  @impl Expert.Provider.Handler
+  def handle(
+        %Requests.TextDocumentImplementation{params: %Structures.ImplementationParams{} = params},
+        %Context{document: document, project: project}
+      ) do
+    case EngineApi.implementation(project, document, params.position) do
+      {:ok, locations} ->
+        {:ok, locations}
+
+      {:error, reason} ->
+        Logger.error("GoToImplementation failed: #{inspect(reason)}")
+        {:ok, []}
+    end
+  end
+end

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -412,6 +412,7 @@ defmodule Expert.State do
         code_lens_provider: code_lens_options,
         completion_provider: completion_options,
         definition_provider: true,
+        implementation_provider: true,
         document_formatting_provider: true,
         document_symbol_provider: true,
         execute_command_provider: command_options,

--- a/apps/expert/test/expert/expert_test.exs
+++ b/apps/expert/test/expert/expert_test.exs
@@ -167,7 +167,10 @@ defmodule ExpertTest do
                )
 
       assert_result(1, %{
-        "capabilities" => %{"workspace" => %{"workspaceFolders" => %{"supported" => true}}}
+        "capabilities" => %{
+          "implementationProvider" => true,
+          "workspace" => %{"workspaceFolders" => %{"supported" => true}}
+        }
       })
 
       assert :ok = notify(client, initialized_notification())

--- a/apps/expert/test/expert/provider/handlers/go_to_implementation_test.exs
+++ b/apps/expert/test/expert/provider/handlers/go_to_implementation_test.exs
@@ -1,0 +1,55 @@
+defmodule Expert.Provider.Handlers.GoToImplementationTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  import Forge.Test.Fixtures
+
+  alias Expert.Document.Context
+  alias Expert.EngineApi
+  alias Expert.Protocol.Convert
+  alias Expert.Provider.Handlers.GoToImplementation
+  alias Forge.Document
+  alias GenLSP.Requests.TextDocumentImplementation
+  alias GenLSP.Structures
+
+  setup_all do
+    start_supervised!(Expert.Application.document_store_child_spec())
+    :ok
+  end
+
+  test "returns engine implementation locations" do
+    project = project()
+    uri = Document.Path.ensure_uri(file_path(project, "lib/project.ex"))
+    document = Document.new(uri, "Example", 1)
+    context = Context.new(uri, document, project)
+    location = :location
+
+    patch(EngineApi, :implementation, {:ok, [location]})
+
+    assert {:ok, [^location]} = GoToImplementation.handle(request(document), context)
+  end
+
+  test "returns an empty list when the engine fails" do
+    project = project()
+    uri = Document.Path.ensure_uri(file_path(project, "lib/project.ex"))
+    document = Document.new(uri, "Example", 1)
+    context = Context.new(uri, document, project)
+
+    patch(EngineApi, :implementation, {:error, :failed})
+
+    assert {:ok, []} = GoToImplementation.handle(request(document), context)
+  end
+
+  defp request(document) do
+    request = %TextDocumentImplementation{
+      id: Expert.Protocol.Id.next(),
+      params: %Structures.ImplementationParams{
+        text_document: %Structures.TextDocumentIdentifier{uri: document.uri},
+        position: %Structures.Position{line: 0, character: 1}
+      }
+    }
+
+    {:ok, request} = Convert.to_native(request, document)
+    request
+  end
+end


### PR DESCRIPTION
Adds support for https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_implementation via ElixirSense