### PR TITLE
fix(forge): handle bitstrings in interpolation

### DIFF
--- a/apps/forge/lib/forge/ast/tokens.ex
+++ b/apps/forge/lib/forge/ast/tokens.ex
@@ -168,7 +168,7 @@ defmodule Forge.Ast.Tokens do
   end
 
   defp get_start_pos([{token, {start_line, start_column, _}} | _])
-       when token in [:"(", :"[", :"{", :%, :%{}] do
+       when token in [:"(", :"[", :"{", :"<<", :%, :%{}] do
     {start_line, start_column}
   end
 

--- a/apps/forge/test/forge/ast/tokens_test.exs
+++ b/apps/forge/test/forge/ast/tokens_test.exs
@@ -215,5 +215,25 @@ defmodule Forge.Ast.TokensTest do
                 ], {1, 1}}
              ]
     end
+
+    test "handles interpolations starting with bitstring literal" do
+      text = ~S'"foo#{<<letter>>}"|'
+
+      {position, document} = pop_cursor(text, as: :document)
+      tokens = Tokens.prefix_stream(document, position)
+
+      assert Enum.to_list(tokens) == [
+               {:interpolated_string,
+                [
+                  {:literal, "foo", {{1, 1}, {1, 4}}},
+                  {:interpolation,
+                   [
+                     {:"<<", {1, 7, nil}},
+                     {:identifier, {1, 9, ~c"letter"}, :letter},
+                     {:">>", {1, 15, nil}}
+                   ], {{1, 7}, {1, 17}}}
+                ], {1, 1}}
+             ]
+    end
   end
 end


### PR DESCRIPTION
## Summary

- recognize bitstring openers when calculating interpolation ranges
- add regression coverage for interpolations beginning with a bitstring

## Testing

- `mix test test/forge/ast/tokens_test.exs`
- `mix test --warnings-as-errors` (3025 passed)
- `mix format --check-formatted`
- `mix credo`
- `mix dialyzer`

Closes #256