### PR TITLE
feat: add signature help

### DIFF
--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -50,6 +50,10 @@ defmodule Engine do
 
   defdelegate hover(document, position), to: CodeIntelligence.Hover
 
+  defdelegate signature_help(document, position),
+    to: CodeIntelligence.SignatureHelp,
+    as: :signature
+
   defdelegate references(analysis, position, include_definitions?),
     to: CodeIntelligence.References
 

--- a/apps/engine/lib/engine/code_intelligence/signature_help.ex
+++ b/apps/engine/lib/engine/code_intelligence/signature_help.ex
@@ -1,0 +1,15 @@
+defmodule Engine.CodeIntelligence.SignatureHelp do
+  @moduledoc """
+  Signature information for the call at a document position.
+  """
+
+  alias Forge.Document
+  alias Forge.Document.Position
+
+  @spec signature(Document.t(), Position.t()) :: map() | :none
+  def signature(%Document{} = document, %Position{} = position) do
+    document
+    |> Document.to_string()
+    |> ElixirSense.signature(position.line, position.character)
+  end
+end

--- a/apps/engine/test/engine/code_intelligence/signature_help_test.exs
+++ b/apps/engine/test/engine/code_intelligence/signature_help_test.exs
@@ -1,0 +1,47 @@
+defmodule Engine.CodeIntelligence.SignatureHelpTest do
+  use ExUnit.Case, async: true
+
+  alias Engine.CodeIntelligence.SignatureHelp
+  alias Forge.Document
+  alias Forge.Document.Position
+
+  test "returns local function signatures and the active parameter" do
+    source = """
+    defmodule SignatureExample do
+      @doc "Adds two values."
+      @spec add(integer(), integer()) :: integer()
+      def add(left, right), do: left + right
+      def use_add do
+        add(1, nil)
+      end
+    end
+    """
+
+    assert %{
+             active_param: 1,
+             signatures: [
+               %{
+                 name: "add",
+                 params: ["left", "right"],
+                 documentation: "Adds two values.",
+                 spec: "@spec add(integer(), integer()) :: integer()"
+               }
+             ]
+           } = signature(source, 6, 11)
+  end
+
+  test "returns signatures for loaded modules" do
+    assert %{active_param: 1, signatures: [%{name: "map", params: ["enumerable", "fun"]}]} =
+             signature("Enum.map([1], &(&1 + 1))", 1, 14)
+  end
+
+  test "returns none outside a call" do
+    assert :none = signature("value", 1, 6)
+  end
+
+  defp signature(source, line, character) do
+    document = Document.new("file:///signature_help_test.ex", source, 0)
+    position = Position.new(document, line, character)
+    SignatureHelp.signature(document, position)
+  end
+end

--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -548,6 +548,9 @@ defmodule Expert do
       %Requests.TextDocumentHover{} ->
         {:ok, Handlers.Hover}
 
+      %Requests.TextDocumentSignatureHelp{} ->
+        {:ok, Handlers.SignatureHelp}
+
       %Requests.WorkspaceExecuteCommand{} ->
         {:ok, Handlers.Commands}
 

--- a/apps/expert/lib/expert/engine_api.ex
+++ b/apps/expert/lib/expert/engine_api.ex
@@ -101,6 +101,10 @@ defmodule Expert.EngineApi do
     call(project, Engine, :hover, [document, position])
   end
 
+  def signature_help(%Project{} = project, %Document{} = document, %Position{} = position) do
+    call(project, Engine, :signature_help, [document, position])
+  end
+
   def references(
         %Project{} = project,
         %Analysis{} = analysis,

--- a/apps/expert/lib/expert/provider/handlers/signature_help.ex
+++ b/apps/expert/lib/expert/provider/handlers/signature_help.ex
@@ -1,0 +1,95 @@
+defmodule Expert.Provider.Handlers.SignatureHelp do
+  @behaviour Expert.Provider.Handler
+
+  alias Expert.Document.Context
+  alias Expert.EngineApi
+  alias Expert.Provider.Markdown
+  alias GenLSP.Requests
+  alias GenLSP.Structures
+
+  @trigger_characters ["(", ","]
+
+  def trigger_characters, do: @trigger_characters
+
+  @impl Expert.Provider.Handler
+  def handle(
+        %Requests.TextDocumentSignatureHelp{params: %Structures.SignatureHelpParams{} = params},
+        %Context{} = context
+      ) do
+    %Context{document: document, project: project} = context
+
+    response =
+      case EngineApi.signature_help(project, document, params.position) do
+        %{active_param: active_param, signatures: [_ | _] = signatures} ->
+          %Structures.SignatureHelp{
+            active_signature: 0,
+            active_parameter: active_param,
+            signatures: Enum.map(signatures, &signature_information/1)
+          }
+
+        _ ->
+          nil
+      end
+
+    {:ok, response}
+  end
+
+  defp signature_information(%{name: name, params: params} = signature) do
+    %Structures.SignatureInformation{
+      label: "#{name}(#{Enum.join(params, ", ")})",
+      parameters: Enum.map(params, &%Structures.ParameterInformation{label: &1}),
+      active_parameter: Map.get(signature, :active_param),
+      documentation: documentation(signature)
+    }
+  end
+
+  defp documentation(signature) do
+    content =
+      Markdown.join_sections([
+        metadata(Map.get(signature, :metadata)),
+        Map.get(signature, :documentation),
+        formatted_spec(Map.get(signature, :spec))
+      ])
+
+    if content != "", do: Markdown.to_content(content)
+  end
+
+  defp formatted_spec(spec) when spec in [nil, ""], do: nil
+
+  defp formatted_spec(spec) do
+    formatted =
+      try do
+        spec
+        |> Code.format_string!(line_length: 42)
+        |> IO.iodata_to_binary()
+      rescue
+        _ -> spec
+      end
+
+    Markdown.code_block(formatted)
+  end
+
+  defp metadata(metadata) when not is_map(metadata), do: nil
+
+  defp metadata(metadata) do
+    metadata
+    |> Enum.sort()
+    |> Enum.map(&metadata_entry/1)
+    |> Markdown.join_sections()
+  end
+
+  defp metadata_entry({:app, app}) when is_atom(app) or is_binary(app),
+    do: "**Application** #{app}"
+
+  defp metadata_entry({:deprecated, message}) when is_binary(message),
+    do: "**Deprecated** #{message}"
+
+  defp metadata_entry({:deprecated, true}), do: "**Deprecated**"
+  defp metadata_entry({:since, version}) when is_binary(version), do: "**Since** #{version}"
+  defp metadata_entry({:guard, true}), do: "**Guard**"
+
+  defp metadata_entry({:implementing, module}) when is_atom(module),
+    do: "**Implementing behaviour** #{inspect(module)}"
+
+  defp metadata_entry(_), do: nil
+end

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -418,6 +418,9 @@ defmodule Expert.State do
         folding_range_provider: true,
         hover_provider: true,
         references_provider: true,
+        signature_help_provider: %Structures.SignatureHelpOptions{
+          trigger_characters: Handlers.SignatureHelp.trigger_characters()
+        },
         text_document_sync: sync_options,
         workspace_symbol_provider: true,
         workspace: %{

--- a/apps/expert/test/expert/provider/handlers/signature_help_test.exs
+++ b/apps/expert/test/expert/provider/handlers/signature_help_test.exs
@@ -1,0 +1,102 @@
+defmodule Expert.Provider.Handlers.SignatureHelpTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  import Forge.Test.Fixtures
+
+  alias Expert.Document.Context
+  alias Expert.EngineApi
+  alias Expert.Protocol.Convert
+  alias Expert.Provider.Handlers.SignatureHelp
+  alias Expert.State
+  alias Forge.Document
+  alias GenLSP.Requests.TextDocumentSignatureHelp
+  alias GenLSP.Structures
+
+  setup do
+    start_supervised!(Expert.Application.document_store_child_spec())
+    Expert.Configuration.new() |> Expert.Configuration.set()
+    on_exit(fn -> :persistent_term.erase(Expert.Configuration) end)
+  end
+
+  test "forwards signature requests and builds an LSP response" do
+    project = project()
+    document = Document.new("file:///signature_help.ex", "Enum.map([1], nil)", 3)
+    context = Context.new(document.uri, document, project)
+
+    lsp_request =
+      %TextDocumentSignatureHelp{
+        id: 1,
+        params: %Structures.SignatureHelpParams{
+          text_document: %Structures.TextDocumentIdentifier{uri: document.uri},
+          position: %Structures.Position{line: 0, character: 14}
+        }
+      }
+
+    assert {:ok, request} = Convert.to_native(lsp_request, document)
+    position = request.params.position
+
+    patch(EngineApi, :signature_help, fn ^project, ^document, ^position ->
+      %{
+        active_param: 1,
+        signatures: [
+          %{
+            active_param: 1,
+            name: "map",
+            params: ["enumerable", "fun"],
+            spec: "@spec map(t(), (element() -> any())) :: list()",
+            documentation: "Maps every element.",
+            metadata: %{app: :elixir}
+          }
+        ]
+      }
+    end)
+
+    assert {:ok,
+            %Structures.SignatureHelp{
+              active_signature: 0,
+              active_parameter: 1,
+              signatures: [
+                %Structures.SignatureInformation{
+                  active_parameter: 1,
+                  label: "map(enumerable, fun)",
+                  parameters: [
+                    %Structures.ParameterInformation{label: "enumerable"},
+                    %Structures.ParameterInformation{label: "fun"}
+                  ],
+                  documentation: %Structures.MarkupContent{kind: "markdown", value: markdown}
+                }
+              ]
+            }} = SignatureHelp.handle(request, context)
+
+    assert markdown =~ "**Application** elixir"
+    assert markdown =~ "Maps every element."
+    assert markdown =~ "```elixir"
+    assert markdown =~ "@spec map"
+  end
+
+  test "returns nil when there is no call at the cursor" do
+    project = project()
+    document = Document.new("file:///signature_help.ex", "value = 1", 1)
+    context = Context.new(document.uri, document, project)
+
+    request =
+      %TextDocumentSignatureHelp{
+        id: 1,
+        params: %Structures.SignatureHelpParams{
+          text_document: %Structures.TextDocumentIdentifier{uri: document.uri},
+          position: %Structures.Position{line: 0, character: 9}
+        }
+      }
+
+    assert {:ok, request} = Convert.to_native(request, document)
+    patch(EngineApi, :signature_help, fn ^project, ^document, _position -> :none end)
+
+    assert {:ok, nil} = SignatureHelp.handle(request, context)
+  end
+
+  test "advertises signature help trigger characters" do
+    assert %Structures.SignatureHelpOptions{trigger_characters: ["(", ","]} =
+             State.initialize_result().capabilities.signature_help_provider
+  end
+end


### PR DESCRIPTION
## Summary

- expose ElixirSense signature data through the project Engine API
- handle `textDocument/signatureHelp` with active parameters, documentation, specs, and selected metadata
- advertise `(` and `,` as signature-help trigger characters

## Testing

- Engine targeted tests: 3 passed
- Expert targeted tests: 3 passed
- Engine full suite: 1164 passed, 19 excluded
- Expert full suite: 844 passed, 12 excluded
- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`, and `mix dialyzer` in both applications

Closes #142