### PR TITLE
fix: use host resolution to check internet

### DIFF
--- a/apps/forge/lib/forge/internet.ex
+++ b/apps/forge/lib/forge/internet.ex
@@ -4,7 +4,7 @@ defmodule Forge.Internet do
     # it seems reasonable to gate pulling dependencies on a resolution check for hex.pm.
     # Yes, it's entirely possible that the DNS server is local, and that the entry is in cache,
     # but that's an edge case, and the build will just time out anyways.
-    case :inet_res.getbyname(~c"hex.pm", :a, 5_000) do
+    case :inet.gethostbyname(~c"hex.pm", :inet, 5_000) do
       {:ok, _} -> true
       _ -> false
     end

--- a/apps/forge/lib/forge/internet.ex
+++ b/apps/forge/lib/forge/internet.ex
@@ -4,8 +4,15 @@ defmodule Forge.Internet do
     # it seems reasonable to gate pulling dependencies on a resolution check for hex.pm.
     # Yes, it's entirely possible that the DNS server is local, and that the entry is in cache,
     # but that's an edge case, and the build will just time out anyways.
-    case :inet.gethostbyname(~c"hex.pm", :inet, 5_000) do
-      {:ok, _} -> true
+    task = Task.async(fn ->
+      case :inet.gethostbyname(~c"hex.pm", :inet) do
+        {:ok, _} -> true
+        _ -> false
+      end
+    end)
+
+    case Task.yield(task, 5_000) || Task.shutdown(task, :brutal_kill) do
+      {:ok, true} -> true
       _ -> false
     end
   end

--- a/apps/forge/lib/forge/internet.ex
+++ b/apps/forge/lib/forge/internet.ex
@@ -4,12 +4,13 @@ defmodule Forge.Internet do
     # it seems reasonable to gate pulling dependencies on a resolution check for hex.pm.
     # Yes, it's entirely possible that the DNS server is local, and that the entry is in cache,
     # but that's an edge case, and the build will just time out anyways.
-    task = Task.async(fn ->
-      case :inet.gethostbyname(~c"hex.pm", :inet) do
-        {:ok, _} -> true
-        _ -> false
-      end
-    end)
+    task =
+      Task.async(fn ->
+        case :inet.gethostbyname(~c"hex.pm", :inet) do
+          {:ok, _} -> true
+          _ -> false
+        end
+      end)
 
     case Task.yield(task, 5_000) || Task.shutdown(task, :brutal_kill) do
       {:ok, true} -> true

--- a/apps/forge/test/forge/internet_test.exs
+++ b/apps/forge/test/forge/internet_test.exs
@@ -5,10 +5,9 @@ defmodule Forge.InternetTest do
   alias Forge.Internet
 
   test "returns true when the OS resolver finds hex.pm within five seconds" do
-    patch(:inet, :gethostbyname, fn host, family, timeout ->
+    patch(:inet, :gethostbyname, fn host, family ->
       assert host == ~c"hex.pm"
       assert family == :inet
-      assert timeout == 5_000
 
       {:ok, :hostent}
     end)
@@ -17,14 +16,36 @@ defmodule Forge.InternetTest do
   end
 
   test "returns false when OS resolution fails" do
-    patch(:inet, :gethostbyname, fn host, family, timeout ->
+    patch(:inet, :gethostbyname, fn host, family ->
       assert host == ~c"hex.pm"
       assert family == :inet
-      assert timeout == 5_000
 
       {:error, :timeout}
     end)
 
     refute Internet.connected_to_internet?()
+  end
+
+  @tag timeout: 10_000
+  test "returns false after five seconds and terminates a blocked resolver" do
+    caller = self()
+
+    patch(:inet, :gethostbyname, fn _host, _family ->
+      Process.flag(:trap_exit, true)
+      send(caller, {:resolver_started, self()})
+      Process.sleep(:infinity)
+    end)
+
+    {elapsed_us, connected?} = :timer.tc(fn -> Internet.connected_to_internet?() end)
+
+    refute connected?
+
+    assert_receive {:resolver_started, pid}
+    refute Process.alive?(pid)
+    refute_receive {_ref, _result}
+    refute_receive {:DOWN, _ref, :process, ^pid, _reason}
+
+    assert elapsed_us >= 5_000_000
+    assert elapsed_us < 6_000_000, "expected a five-second timeout, took #{elapsed_us} us"
   end
 end

--- a/apps/forge/test/forge/internet_test.exs
+++ b/apps/forge/test/forge/internet_test.exs
@@ -4,10 +4,10 @@ defmodule Forge.InternetTest do
 
   alias Forge.Internet
 
-  test "returns true when hex.pm resolves within five seconds" do
-    patch(:inet_res, :getbyname, fn host, family, timeout ->
+  test "returns true when the OS resolver finds hex.pm within five seconds" do
+    patch(:inet, :gethostbyname, fn host, family, timeout ->
       assert host == ~c"hex.pm"
-      assert family == :a
+      assert family == :inet
       assert timeout == 5_000
 
       {:ok, :hostent}
@@ -16,10 +16,10 @@ defmodule Forge.InternetTest do
     assert Internet.connected_to_internet?()
   end
 
-  test "returns false when hex.pm resolution fails" do
-    patch(:inet_res, :getbyname, fn host, family, timeout ->
+  test "returns false when OS resolution fails" do
+    patch(:inet, :gethostbyname, fn host, family, timeout ->
       assert host == ~c"hex.pm"
-      assert family == :a
+      assert family == :inet
       assert timeout == 5_000
 
       {:error, :timeout}


### PR DESCRIPTION
Using a direct DNS query causes false negatives in windows

Should fix #861, what I reproduced from that issue on my windows machine is that the connectivity check would incorrectly fail and `mix local.hex` would be skipped, causing `mix loadpaths` to hang.

This does not happen in stable because it doesn't include the changes to further isolate the mix homes for the engine build and the project builds, and because we no longer try to always force install hex/rebar