### PR TITLE
fix: diagnostics take a long time to update

### DIFF
--- a/apps/engine/lib/engine/compilation/trace_buffer.ex
+++ b/apps/engine/lib/engine/compilation/trace_buffer.ex
@@ -22,18 +22,12 @@ defmodule Engine.Compilation.TraceBuffer do
 
   def record_module(_path, _binary), do: :ok
 
-  def record_module(path, binary, module, definitions)
-      when is_binary(path) and is_binary(binary) and is_atom(module) and is_list(definitions) do
-    true =
-      :ets.insert(
-        @table,
-        {Forge.Path.native(path), binary, module, definitions}
-      )
-
-    :ok
+  def record_module(path, binary, module)
+      when is_binary(path) and is_binary(binary) and is_atom(module) do
+    GenServer.cast(__MODULE__, {:record_module, path, binary, module})
   end
 
-  def record_module(_path, _binary, _module, _definitions), do: :ok
+  def record_module(_path, _binary, _module), do: :ok
 
   @impl GenServer
   def init(%__MODULE__{} = state) do
@@ -51,6 +45,27 @@ defmodule Engine.Compilation.TraceBuffer do
     definitions = definitions_by_path(live_events())
     clear_live()
     {:reply, {:ok, definitions}, state}
+  end
+
+  @impl GenServer
+  def handle_cast({:record_module, path, binary, module}, state) do
+    definitions =
+      module
+      |> Module.definitions_in()
+      |> Enum.flat_map(fn definition ->
+        case Module.get_definition(module, definition, skip_clauses: true) do
+          {:v1, kind, metadata, []} -> [{definition, kind, metadata}]
+          _ -> []
+        end
+      end)
+
+    true =
+      :ets.insert(
+        @table,
+        {Forge.Path.native(path), binary, module, definitions}
+      )
+
+    {:noreply, state}
   end
 
   defp call(message, timeout \\ 5_000), do: GenServer.call(__MODULE__, message, timeout)

--- a/apps/engine/lib/engine/compilation/tracer.ex
+++ b/apps/engine/lib/engine/compilation/tracer.ex
@@ -53,17 +53,7 @@ defmodule Engine.Compilation.Tracer do
 
   defp maybe_record_module(file, module_binary, module)
        when is_binary(file) and is_binary(module_binary) and is_atom(module) do
-    definitions =
-      module
-      |> Module.definitions_in()
-      |> Enum.flat_map(fn definition ->
-        case Module.get_definition(module, definition, skip_clauses: true) do
-          {:v1, kind, metadata, []} -> [{definition, kind, metadata}]
-          _ -> []
-        end
-      end)
-
-    TraceBuffer.record_module(file, module_binary, module, definitions)
+    TraceBuffer.record_module(file, module_binary, module)
   end
 
   defp maybe_record_module(_file, _module_binary, _module), do: :ok


### PR DESCRIPTION
I was noticing that compilation errors were taking a lot of time to clear. This is because the compile tracer was doing synchrounous work before it updated the trace buffer. This would slow down compilation enough that it wouldn't complete, and thus, we wouldn't get cleared diagnostics for seconds.

Moving this work into the trace buffer's genserver clears the path for compilation to continue, and now diagnostics clear (and appear) much more quickly.