### PR TITLE
fix(engine): drop edit window to 100ms

### DIFF
--- a/apps/engine/lib/engine/build/state.ex
+++ b/apps/engine/lib/engine/build/state.ex
@@ -112,7 +112,7 @@ defmodule Engine.Build.State do
   def last_deps_fetch_result(%__MODULE__{last_deps_fetch_result: result}), do: result
 
   def edit_window_millis do
-    Application.get_env(:engine, :edit_window_millis, 1000)
+    Application.get_env(:engine, :edit_window_millis, 100)
   end
 
   defp normalize_fetch_deps_result({:ok, :ok}), do: :ok


### PR DESCRIPTION
100ms is typically the threshold for things feeling slow. We bumped the edit window to a second, which made diagnostics changing feel very slow. This reduces it to the "slow threshold"