### PR TITLE
fix: record module binary if module metata read fails

### DIFF
--- a/apps/engine/lib/engine/compilation/trace_buffer.ex
+++ b/apps/engine/lib/engine/compilation/trace_buffer.ex
@@ -66,6 +66,10 @@ defmodule Engine.Compilation.TraceBuffer do
       )
 
     {:noreply, state}
+  rescue
+    _ ->
+      record_module(path, binary)
+      {:noreply, state}
   end
 
   defp call(message, timeout \\ 5_000), do: GenServer.call(__MODULE__, message, timeout)


### PR DESCRIPTION
It's possible that the module finishes compiling in the time between the time it's reported in the compile tracer and when the trace buffer handle it. If this happens, a function clause error is raised, which will crash the server.

This fix catches the function clause error, and uses the module's binary to get the module's information.