### PR TITLE
chore(revert): prevent formatter cache from forgetting the formatter for a path (#831)

### DIFF
--- a/apps/engine/lib/engine/code_mod/format/cache.ex
+++ b/apps/engine/lib/engine/code_mod/format/cache.ex
@@ -35,14 +35,15 @@ defmodule Engine.CodeMod.Format.Cache do
   defmodule Entry do
     @moduledoc false
 
-    defstruct [:id, :formatter, :opts, :extension]
+    defstruct [:id, :formatter, :opts, :extension, :path]
     @type id :: non_neg_integer()
 
     @type t :: %__MODULE__{
             id: id(),
             formatter: Engine.CodeMod.Format.formatter_function(),
             opts: keyword(),
-            extension: String.t()
+            extension: String.t(),
+            path: Path.t()
           }
 
     @spec new(Format.formatter_function(), keyword(), Path.t()) :: t()
@@ -53,7 +54,8 @@ defmodule Engine.CodeMod.Format.Cache do
         id: :erlang.unique_integer([:positive]),
         formatter: formatter,
         opts: opts,
-        extension: extension
+        extension: extension,
+        path: file_path
       }
     end
 
@@ -328,25 +330,18 @@ defmodule Engine.CodeMod.Format.Cache do
   end
 
   defp clean_closed_entries do
-    @paths_table
-    |> :ets.tab2list()
-    |> Enum.each(fn path_row(path: path) ->
-      if not (path |> Document.Path.to_uri() |> Document.Store.open?()) do
-        true = :ets.delete(@paths_table, path)
-      end
-    end)
-
-    referenced_entry_ids =
-      @paths_table
+    closed_entries =
+      @entries_table
       |> :ets.tab2list()
-      |> MapSet.new(fn path_row(entry_id: entry_id) -> entry_id end)
+      |> Enum.reject(fn entry_row(entry: %Entry{} = entry) ->
+        entry.path
+        |> Document.Path.to_uri()
+        |> Document.Store.open?()
+      end)
 
-    @entries_table
-    |> :ets.tab2list()
-    |> Enum.each(fn entry_row(id: entry_id) ->
-      if !MapSet.member?(referenced_entry_ids, entry_id) do
-        true = :ets.delete(@entries_table, entry_id)
-      end
+    Enum.each(closed_entries, fn entry_row(entry: %Entry{} = entry) ->
+      true = :ets.delete(@entries_table, entry.id)
+      true = :ets.delete(@paths_table, entry.path)
     end)
   end
 end

--- a/apps/engine/test/engine/code_mod/format/cache_test.exs
+++ b/apps/engine/test/engine/code_mod/format/cache_test.exs
@@ -82,28 +82,6 @@ defmodule Engine.CodeMod.Format.CacheTest do
     refute_called(Cache.State.put_dot_formatters(_, _))
   end
 
-  test "refresh retains a shared formatter until every path is closed", ctx do
-    patch_resolver()
-
-    assert {:ok, _, _} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
-    assert {:ok, _, _} = Cache.fetch_formatter(ctx.project, ctx.other_ex_path)
-    assert_called(Resolver.resolve(_, _), 1)
-
-    :ok = ctx.ex_path |> Document.Path.to_uri() |> Document.Store.close()
-    refresh()
-
-    assert {:ok, _, _} = Cache.fetch_formatter(ctx.project, ctx.other_ex_path)
-    assert_called(Resolver.resolve(_, _), 1)
-
-    other_ex_uri = Document.Path.to_uri(ctx.other_ex_path)
-    :ok = Document.Store.close(other_ex_uri)
-    refresh()
-    :ok = Document.Store.open(other_ex_uri, "", 2)
-
-    assert {:ok, _, _} = Cache.fetch_formatter(ctx.project, ctx.other_ex_path)
-    assert_called(Resolver.resolve(_, _), 2)
-  end
-
   test "a changed .formatter.exs clears the cache on refresh", ctx do
     patch_resolver()
     assert {:ok, _, opts} = Cache.fetch_formatter(ctx.project, ctx.ex_path)


### PR DESCRIPTION
This reverts commit 8bc8afca704e78d6f7c38ae42d9a95915281f0f5.

That commit fixed the wrong problem and introduces a different issue.

The formatter cannot be shared by multiple files, which is what that commit does. The problem it tried to fix is that the formatter cache would get emptied and then cache the miss, and that requires a different fix.
