### PR TITLE
fix: read beam binary directly instead of using Module functions

### DIFF
--- a/apps/engine/lib/engine/compilation/trace_buffer.ex
+++ b/apps/engine/lib/engine/compilation/trace_buffer.ex
@@ -50,14 +50,13 @@ defmodule Engine.Compilation.TraceBuffer do
   @impl GenServer
   def handle_cast({:record_module, path, binary, module}, state) do
     definitions =
-      module
-      |> Module.definitions_in()
-      |> Enum.flat_map(fn definition ->
-        case Module.get_definition(module, definition, skip_clauses: true) do
-          {:v1, kind, metadata, []} -> [{definition, kind, metadata}]
-          _ -> []
-        end
-      end)
+      case Beams.debug_metadata_from_binary(binary) do
+        {:ok, metadata} ->
+          for {def, kind, meta, _} <- metadata[:definitions], do: {def, kind, meta}
+
+        _ ->
+          []
+      end
 
     true =
       :ets.insert(

--- a/apps/engine/lib/engine/search/indexer/beams.ex
+++ b/apps/engine/lib/engine/search/indexer/beams.ex
@@ -201,9 +201,12 @@ defmodule Engine.Search.Indexer.Beams do
     [{:skipped, manifest_entry}]
   end
 
+  @doc """
+  Returns the debug_info metadata chunk from the provided beam path.
+  """
   # The debug-info chunk data is backend-owned and opaque. The public contract is
   # to ask the backend to decode it into the Elixir debug-info format we consume.
-  defp debug_metadata(beam_path) do
+  def debug_metadata(beam_path) do
     with {:ok, {module, [debug_info: {:debug_info_v1, backend, data}]}} <-
            :beam_lib.chunks(String.to_charlist(beam_path), [:debug_info]),
          {:ok, metadata} when is_map(metadata) <- backend.debug_info(:elixir_v1, module, data, []) do
@@ -211,11 +214,12 @@ defmodule Engine.Search.Indexer.Beams do
     else
       _ -> :error
     end
-  catch
-    _kind, _reason -> :error
   end
 
-  defp debug_metadata_from_binary(beam) do
+  @doc """
+  Returns the debug_info metadata chunk from the provided beam binary.
+  """
+  def debug_metadata_from_binary(beam) do
     with {:ok, {module, [debug_info: {:debug_info_v1, backend, data}]}} <-
            :beam_lib.chunks(beam, [:debug_info]),
          {:ok, metadata} when is_map(metadata) <- backend.debug_info(:elixir_v1, module, data, []) do
@@ -223,8 +227,6 @@ defmodule Engine.Search.Indexer.Beams do
     else
       _ -> :error
     end
-  catch
-    _kind, _reason -> :error
   end
 
   defp entries_from_metadata(metadata, source_lines) do


### PR DESCRIPTION
#856 introduced `Module.definitions_in` in the tracer(later moved to the tracebuffer). [That function's docs](https://elixir.hexdocs.pm/Module.html#definitions_in/1) specify that "This function can only be used on modules that have not yet been compiled". We cannot guarantee in the tracebuffer that the module was not yet been compiled, so we can't use that function. Also we already have the module binary available, so we should be reading that instead anyways.

This PR removes that function and reads the module binary for definitions like we do in the rest of the codebase.