### PR TITLE
fix: clear stale diagnostics as you type

### DIFF
--- a/apps/expert/lib/expert/project/diagnostics.ex
+++ b/apps/expert/lib/expert/project/diagnostics.ex
@@ -64,6 +64,8 @@ defmodule Expert.Project.Diagnostics do
         file_diagnostics(uri: uri, build_number: build_number, diagnostics: diagnostics),
         %State{} = state
       ) do
+    state = State.clear_stale_project_diagnostics(state, uri)
+
     state =
       case diagnostics do
         [] ->

--- a/apps/expert/lib/expert/project/diagnostics/state.ex
+++ b/apps/expert/lib/expert/project/diagnostics/state.ex
@@ -70,6 +70,19 @@ defmodule Expert.Project.Diagnostics.State do
     %__MODULE__{state | file_entries_by_uri: file_entries}
   end
 
+  def clear_stale_project_diagnostics(%__MODULE__{} = state, source_uri) do
+    case Document.Store.fetch(source_uri) do
+      {:ok, %Document{dirty?: true}} ->
+        entries_by_uri =
+          Map.put(state.entries_by_uri, source_uri, Entry.new(0))
+
+        %__MODULE__{state | entries_by_uri: entries_by_uri}
+
+      _ ->
+        state
+    end
+  end
+
   @doc """
   Only clear diagnostics if they've been synced to disk
   It's possible that the diagnostic presented by typing is still correct, and the file

--- a/apps/expert/test/expert/project/diagnostics_test.exs
+++ b/apps/expert/test/expert/project/diagnostics_test.exs
@@ -140,7 +140,9 @@ defmodule Expert.Project.DiagnosticsTest do
         project,
         project_diagnostics(
           build_number: 1,
-          diagnostics: [diagnostic(document.uri, message: "boundary warning")]
+          diagnostics: [
+            diagnostic(document.uri, message: "boundary warning", source: "Boundary")
+          ]
         )
       )
 
@@ -153,6 +155,39 @@ defmodule Expert.Project.DiagnosticsTest do
                         params: %PublishDiagnosticsParams{
                           diagnostics: [%Structures.Diagnostic{message: "boundary warning"}]
                         }
+                      }}
+    end
+
+    test "it clears stale project compiler diagnostics when a file compiles cleanly", %{
+      project: project
+    } do
+      document = open_file(project, "defmodule Dummy")
+
+      EngineApi.broadcast(
+        project,
+        project_diagnostics(
+          build_number: 1,
+          diagnostics: [
+            diagnostic(document.uri,
+              message: "undefined function missing/0",
+              source: "Elixir"
+            )
+          ]
+        )
+      )
+
+      assert_receive {:transport, %TextDocumentPublishDiagnostics{}}
+
+      {:ok, document} =
+        Document.Store.get_and_update(document.uri, fn document ->
+          {:ok, Document.mark_dirty(document)}
+        end)
+
+      EngineApi.broadcast(project, file_diagnostics(build_number: 2, uri: document.uri))
+
+      assert_receive {:transport,
+                      %TextDocumentPublishDiagnostics{
+                        params: %PublishDiagnosticsParams{diagnostics: []}
                       }}
     end
   end


### PR DESCRIPTION
Fixes diagnostics not clearing until you save the file

Say you have this:

```elixir
def foo(bar) do
  {:ok, bar}
end
```
Then change `bar` to `baz` without saving, you will get an `unused variable baz` warning. Fixing it will remove the diagnostic.
If you change it to `baz`, get the diagnostic, save the document, then fix it back to `bar`, the `unused variable` diagnostic will not go away until you save the file.

This is caused by project diagnostics not being cleared when you type. This change makes such that dirty files clear the project diagnostics.

This also means that if project compilation produces a diagnostic that file compilation cannot produce, a dirty document will not show them. I have not yet found a way to reliably display both, keeping only the valid diagnostics, as we need to compile the project anyways to get the right diagnostics anyways.