### PR TITLE
fix: properly handle typespec errors; prevent diagnostics crash

### DIFF
--- a/apps/engine/lib/engine/build/error.ex
+++ b/apps/engine/lib/engine/build/error.ex
@@ -197,6 +197,33 @@ defmodule Engine.Build.Error do
     Diagnostic.new(source.uri, position, message, :error, @elixir_source)
   end
 
+  def error_to_diagnostic(
+        %Document{} = source,
+        %Kernel.TypespecError{} = typespec_error,
+        _stack,
+        _quoted_ast
+      ) do
+    path = typespec_error.file || source.path
+    position = Location.position(typespec_error.line || 1)
+    message = Exception.message(typespec_error)
+
+    Diagnostic.new(path, position, message, :error, @elixir_source)
+  end
+
+  def error_to_diagnostic(%Document{} = source, unhandled, stack, _quoted_ast) do
+    # Fallback for everything not captured above
+    message =
+      if is_exception(unhandled) do
+        Exception.message(unhandled)
+      else
+        inspect(unhandled)
+      end
+
+    position = Location.stack_to_position(stack) || 1
+
+    Diagnostic.new(source.uri, position, message, :error, @elixir_source)
+  end
+
   def message_to_diagnostic(%Document{} = document, message_string) do
     message_string
     |> extract_individual_messages()

--- a/apps/engine/lib/engine/build/isolation.ex
+++ b/apps/engine/lib/engine/build/isolation.ex
@@ -18,6 +18,11 @@ defmodule Engine.Build.Isolation do
         Process.demonitor(ref, [:flush])
         {:ok, result}
 
+      {:DOWN, ^ref, :process, ^pid, {reason, stacktrace}} when is_list(stacktrace) ->
+        # normalize the error into an exception struct so callers can handle it.
+
+        {:error, {Exception.normalize(:error, reason, stacktrace), stacktrace}}
+
       {:DOWN, ^ref, :process, ^pid, reason} ->
         {:error, reason}
     end

--- a/apps/engine/test/engine/build/error_test.exs
+++ b/apps/engine/test/engine/build/error_test.exs
@@ -512,6 +512,22 @@ defmodule Engine.Build.ErrorTest do
       assert decorate(document_text, diagnostic.position) =~ "«defmodule Foo do\n»"
     end
 
+    test "handles Kernel.TypespecError" do
+      document_text = ~S[defmodule Foo do
+        @spec bar() :: undefined_type()
+        def bar, do: :ok
+      end
+      ]
+
+      diagnostic =
+        document_text
+        |> compile()
+        |> diagnostic()
+
+      assert diagnostic.message =~ ~s[type undefined_type/0 undefined]
+      assert decorate(document_text, diagnostic.position) =~ "«@spec bar() :: undefined_type()\n»"
+    end
+
     test "handles ExUnit.DuplicateTestError" do
       document_text = ~s[
         defmodule FooTest do

--- a/apps/engine/test/engine/build/isolation_test.exs
+++ b/apps/engine/test/engine/build/isolation_test.exs
@@ -1,0 +1,40 @@
+defmodule Engine.Build.IsolationTest do
+  use ExUnit.Case
+
+  alias Engine.Build.Isolation
+
+  defmodule OnlyMatchesOne do
+    def call(1) do
+      :ok
+    end
+  end
+
+  test "returns {:ok, result} when the function succeeds" do
+    assert {:ok, :ok} = Isolation.invoke(fn -> :ok end)
+  end
+
+  test "normalizes a raw function-clause crash into a proper exception" do
+    assert {:error, {exception, stacktrace}} =
+             Isolation.invoke(fn -> OnlyMatchesOne.call("not an integer") end)
+
+    assert %FunctionClauseError{module: OnlyMatchesOne, function: :call, arity: 1} = exception
+    assert [{OnlyMatchesOne, :call, _, _} | _] = stacktrace
+  end
+
+  test "keeps a raised exception struct" do
+    assert {:error, {exception, stacktrace}} =
+             Isolation.invoke(fn -> raise ArgumentError, "boom" end)
+
+    assert %ArgumentError{message: "boom"} = exception
+    assert is_list(stacktrace)
+  end
+
+  test "handles an exit" do
+    assert {:error, :boom} =
+             Isolation.invoke(fn -> exit(:boom) end)
+  end
+
+  test "handles a kill" do
+    assert {:error, :killed} = Isolation.invoke(fn -> Process.exit(self(), :kill) end)
+  end
+end

--- a/apps/expert/lib/expert/project/diagnostics/state.ex
+++ b/apps/expert/lib/expert/project/diagnostics/state.ex
@@ -99,6 +99,11 @@ defmodule Expert.Project.Diagnostics.State do
     %__MODULE__{state | file_entries_by_uri: file_entries_by_uri}
   end
 
+  def add_file(%__MODULE__{} = state, _build_number, unknown) do
+    Logger.error("Tried to add #{inspect(unknown)} as a diagnostic.")
+    state
+  end
+
   defp add_to_entries(entries_by_uri, build_number, diagnostic) do
     Map.update(
       entries_by_uri,


### PR DESCRIPTION
If a typespec error (or any unhandled error) occured during a build, it was not being handled properly by Build.Isolation, and was emitted as a three-tuple of {:error, exception, stack}. This was then handed to Build.Error, which didn't know what to do with it, crashing the diagnostics server. Even if it was handed a typespec error, Diagnostics wouldn't handle it properly due to a missing clause, and it would crash because the diagnostic state module's add_file didn't have a catchall clause.

This PR fixes all of the above.