### PR TITLE
feat(expert): fold anonymous functions

### DIFF
--- a/apps/expert/lib/expert/provider/handlers/code_folding.ex
+++ b/apps/expert/lib/expert/provider/handlers/code_folding.ex
@@ -40,6 +40,9 @@ defmodule Expert.Provider.Handlers.CodeFolding do
   defp block_ranges(ast) do
     {_, ranges} =
       Macro.prewalk(ast, [], fn
+        {:fn, meta, _clauses} = node, acc when is_list(meta) ->
+          {node, collect_anonymous_function(meta, acc)}
+
         {_form, meta, _args} = node, acc when is_list(meta) ->
           {node, collect_block(meta, acc)}
 
@@ -63,6 +66,17 @@ defmodule Expert.Provider.Handlers.CodeFolding do
     end
   end
 
+  defp collect_anonymous_function(meta, acc) do
+    opening_line = Keyword.get(meta, :line)
+    closing_line = meta_line(meta, :closing)
+
+    if is_integer(opening_line) and is_integer(closing_line) do
+      [{opening_line, closing_line} | acc]
+    else
+      acc
+    end
+  end
+
   defp meta_line(meta, key) do
     case Keyword.get(meta, key) do
       keyword when is_list(keyword) -> Keyword.get(keyword, :line)
@@ -70,9 +84,9 @@ defmodule Expert.Provider.Handlers.CodeFolding do
     end
   end
 
-  defp to_block_folding_range({do_line, end_line}) do
-    start_line = do_line - 1
-    last_line = end_line - 2
+  defp to_block_folding_range({opening_line, closing_line}) do
+    start_line = opening_line - 1
+    last_line = closing_line - 2
 
     if last_line > start_line do
       %Structures.FoldingRange{start_line: start_line, end_line: last_line}

--- a/apps/expert/test/expert/provider/handlers/code_folding_test.exs
+++ b/apps/expert/test/expert/provider/handlers/code_folding_test.exs
@@ -102,6 +102,48 @@ defmodule Expert.Provider.Handlers.CodeFoldingTest do
     end
   end
 
+  describe "anonymous functions" do
+    test "folds a multi-line anonymous function" do
+      source = """
+      callback = fn value ->
+        value + 1
+      end
+      """
+
+      assert fold(source) == [range(0, 1)]
+    end
+
+    test "folds nested anonymous functions" do
+      source = """
+      outer = fn value ->
+        inner = fn ->
+          value
+        end
+        inner.()
+      end
+      """
+
+      assert fold(source) == [range(0, 4), range(1, 2)]
+    end
+
+    test "folds a multi-clause anonymous function" do
+      source = """
+      formatter = fn
+        :ok ->
+          "ok"
+        :error ->
+          "error"
+      end
+      """
+
+      assert fold(source) == [range(0, 4)]
+    end
+
+    test "does not fold a single-line anonymous function" do
+      assert fold("callback = fn value -> value end\n") == []
+    end
+  end
+
   describe "heredocs" do
     test "folds a multi-line @moduledoc heredoc" do
       source = """


### PR DESCRIPTION
## Summary

- Add folding ranges for multi-line anonymous functions.
- Use parser closing metadata so the final `end` line remains visible.
- Cover simple, nested, multi-clause, and single-line anonymous functions.

## Validation

- `mix test test/expert/provider/handlers/code_folding_test.exs --warnings-as-errors` (25 passed)
- `mix test --warnings-as-errors` (849 passed, 12 excluded)
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`

Refs #146