### PR TITLE
fix: don't reverse text document params

### DIFF
--- a/apps/expert/lib/convertibles/gen_lsp.structures.did_change_text_document_params.ex
+++ b/apps/expert/lib/convertibles/gen_lsp.structures.did_change_text_document_params.ex
@@ -1,0 +1,11 @@
+defimpl Forge.Protocol.Convertible, for: GenLSP.Structures.DidChangeTextDocumentParams do
+  alias GenLSP.Structures.DidChangeTextDocumentParams
+
+  def to_native(%DidChangeTextDocumentParams{} = params, _context_document) do
+    {:ok, params}
+  end
+
+  def to_lsp(%DidChangeTextDocumentParams{} = params) do
+    {:ok, params}
+  end
+end

--- a/apps/expert/test/expert/expert_test.exs
+++ b/apps/expert/test/expert/expert_test.exs
@@ -861,6 +861,76 @@ defmodule ExpertTest do
   end
 
   describe "text document changes" do
+    test "applies batched incremental changes against the preceding change", %{
+      client: client,
+      project_root: project_root,
+      main_project: main_project
+    } do
+      test_pid = self()
+
+      change = fn line, character, text ->
+        position = %{line: line, character: character}
+        %{text: text, range: %{start: position, end: position}}
+      end
+
+      patch(Expert.EngineApi, :broadcast, fn _project, _message -> :ok end)
+
+      patch(Expert.EngineApi, :compile_document, fn _project, document ->
+        send(test_pid, {:compiled_document, Document.to_string(document)})
+        :ok
+      end)
+
+      assert :ok =
+               request(
+                 client,
+                 initialize_request(project_root, id: 1, projects: [main_project])
+               )
+
+      assert_result(1, _)
+      assert Expert.Project.Store.transition(main_project, :ready)
+
+      file_uri =
+        Document.Path.to_uri(Path.join([project_root, "main", "lib", "sequential_changes.ex"]))
+
+      assert :ok =
+               notify(client, %{
+                 method: "textDocument/didOpen",
+                 jsonrpc: "2.0",
+                 params: %{
+                   textDocument: %{
+                     uri: file_uri,
+                     languageId: "elixir",
+                     version: 1,
+                     text: "defmodule Repro do"
+                   }
+                 }
+               })
+
+      assert_eventually(match?({:ok, _document}, Document.Store.fetch(file_uri)))
+
+      assert :ok =
+               notify(client, %{
+                 method: "textDocument/didChange",
+                 jsonrpc: "2.0",
+                 params: %{
+                   textDocument: %{uri: file_uri, version: 2},
+                   contentChanges: [
+                     change.(0, 18, "\n"),
+                     change.(1, 0, "d"),
+                     change.(1, 1, "e"),
+                     change.(1, 2, "f")
+                   ]
+                 }
+               })
+
+      expected = "defmodule Repro do\ndef"
+
+      assert_receive {:compiled_document, compiled_document}
+      assert compiled_document == expected
+      assert {:ok, document} = Document.Store.fetch(file_uri)
+      assert Document.to_string(document) == expected
+    end
+
     test "compileOnType controls document compilation without suppressing change broadcasts", %{
       client: client,
       project_root: project_root,


### PR DESCRIPTION
I have not been able to reproduce this myself, but every now and then someone reports a weird diagnostic where a part of it is reversed, like this screenshot:

<img width="600" height="324" alt="Screenshot 2026-09-05 at 5 27 28 PM" src="https://github.com/user-attachments/assets/67e4ef37-3ea4-44cd-a5d9-346d6bd702ba" />

Notice how it says `fed/2` is undefined, which would mean `def/2` instead, and that function does exist and is in scope. This is usually sporadic and users report that "it fixes by itself".

With a synthetic reproduction test I was able to verify that we are indeed sometimes reversing the `textDocument/didChange` params if it contains multiple sequential edits, due to a missing protocol implementation for `Forge.Protocol.Convertible` for that structure, which made it default to the List implementation and be put through an `Enum.reduce_while` that reversed it.

My guess is that if you type `def` and make a short pause before continuing typing, the client will send `d`, `e` and `f` as multiple sequential changes instead of a single `def` addition, that sequence gets accidentally reversed, and we get those spurious diagnostics with mangled names, so this is what this PR reproduces and fixes.