### PR TITLE
fix: stop checking dependency beam mtime

### DIFF
--- a/apps/engine/lib/engine/search/indexer/beams.ex
+++ b/apps/engine/lib/engine/search/indexer/beams.ex
@@ -164,13 +164,15 @@ defmodule Engine.Search.Indexer.Beams do
     source_path = Map.get(metadata, :file)
     source_stat_result = stat_source(source_path)
 
-    if fresh_beam?(beam_stat, source_stat_result) do
-      {:ok, manifest_entry} =
-        Manifest.Entry.beam(beam_path, source_path, beam_stat, source_stat_result)
+    case source_stat_result do
+      {:ok, _source_stat} ->
+        {:ok, manifest_entry} =
+          Manifest.Entry.beam(beam_path, source_path, beam_stat, source_stat_result)
 
-      [{:indexed, source_path, metadata, manifest_entry}]
-    else
-      skipped_result_from_beam(beam_path, beam_stat, source_path, source_stat_result)
+        [{:indexed, source_path, metadata, manifest_entry}]
+
+      :error ->
+        skipped_result_from_beam(beam_path, beam_stat, source_path, source_stat_result)
     end
   end
 
@@ -182,12 +184,6 @@ defmodule Engine.Search.Indexer.Beams do
   end
 
   defp stat_source(_source_path), do: :error
-
-  defp fresh_beam?(%File.Stat{} = beam_stat, {:ok, %File.Stat{} = source_stat}) do
-    beam_stat.mtime >= source_stat.mtime
-  end
-
-  defp fresh_beam?(_beam_stat, _source_stat), do: false
 
   defp skipped_result_from_beam(beam_path, beam_stat, source_path, source_stat_result) do
     {:ok, manifest_entry} =

--- a/apps/engine/test/engine/search/indexer_test.exs
+++ b/apps/engine/test/engine/search/indexer_test.exs
@@ -10,6 +10,7 @@ defmodule Engine.Search.IndexerTest do
   alias Engine.Search.Indexer.Manifest
   alias Engine.Search.Indexer.Manifest.Entry, as: ManifestEntry
   alias Engine.Search.Indexer.ManifestStore
+  alias Engine.Search.Indexer.Source
   alias Forge.Project
   alias Forge.Search.Indexer.Entry
 
@@ -270,19 +271,27 @@ defmodule Engine.Search.IndexerTest do
     end
 
     @tag :tmp_dir
-    test "caches stale dependency beams without entries", %{tmp_dir: tmp_dir} do
+    test "uses BEAM metadata for public dependency definitions", %{tmp_dir: tmp_dir} do
       %{beam_path: beam_path, dep_file: dep_file, module: module, project: project} =
         with_beam_dependency(tmp_dir, rewrite_source?: false)
 
       File.touch!(dep_file, {{2100, 1, 1}, {0, 0, 0}})
+      spy(Source)
 
       assert {entries, []} = update_index(project)
       assert {:ok, manifest} = ManifestStore.load(project)
 
-      refute Enum.any?(entries, &(&1.subject == module))
+      assert Enum.any?(entries, &(&1.subject == module and &1.subtype == :definition))
 
-      assert {:ok, %ManifestEntry{kind: :beam, output_path: nil, source_path: ^dep_file}} =
+      assert Enum.any?(entries, &(&1.subject == Forge.Formats.mfa(module, :public_fun, 0)))
+      refute Enum.any?(entries, &(&1.subject == Forge.Formats.mfa(module, :private_fun, 0)))
+      refute_called(Source.index(^dep_file, _, _))
+
+      assert {:ok, %ManifestEntry{kind: :beam, output_path: ^dep_file, source_path: ^dep_file}} =
                Manifest.fetch(manifest, beam_path)
+
+      FakeBackend.set_entries(entries)
+      assert {[], []} = update_index(project)
     end
 
     @tag :tmp_dir
@@ -342,16 +351,61 @@ defmodule Engine.Search.IndexerTest do
     end
 
     @tag :tmp_dir
-    test "clears entries when beam metadata is stale", %{tmp_dir: tmp_dir} do
-      %{dep_file: dep_file, project: project} = with_beam_dependency(tmp_dir)
+    test "retains compiled definitions when newer source cannot be parsed", %{tmp_dir: tmp_dir} do
+      %{dep_file: dep_file, module: module, project: project} = with_beam_dependency(tmp_dir)
 
       entries = create_index(project)
       FakeBackend.set_entries(entries)
 
       File.touch!(dep_file, {{2100, 1, 1}, {0, 0, 0}})
 
-      assert {[], paths_to_clear} = update_index(project)
-      assert dep_file in paths_to_clear
+      assert {updated_entries, []} = update_index(project)
+      assert Enum.any?(updated_entries, &(&1.subject == module and &1.subtype == :definition))
+
+      assert Enum.any?(
+               updated_entries,
+               &(&1.subject == Forge.Formats.mfa(module, :public_fun, 0))
+             )
+
+      refute Enum.any?(updated_entries, &(&1.path == dep_file and &1.subtype == :reference))
+    end
+
+    @tag :tmp_dir
+    test "refreshes dependency definitions after recompilation", %{tmp_dir: tmp_dir} do
+      %{beam_path: beam_path, dep_file: dep_file, module: module, project: project} =
+        with_beam_dependency(tmp_dir, rewrite_source?: false)
+
+      FakeBackend.set_entries(create_index(project))
+
+      File.write!(dep_file, """
+      defmodule #{inspect(module)} do
+        def newly_compiled_function, do: :updated
+      end
+      """)
+
+      File.touch!(dep_file, {{2100, 1, 1}, {0, 0, 0}})
+
+      assert {before_compile, []} = update_index(project)
+      assert Enum.any?(before_compile, &(&1.subject == Forge.Formats.mfa(module, :public_fun, 0)))
+
+      refute Enum.any?(
+               before_compile,
+               &(&1.subject == Forge.Formats.mfa(module, :newly_compiled_function, 0))
+             )
+
+      FakeBackend.set_entries(before_compile)
+      Code.compiler_options(ignore_module_conflict: true)
+      assert [^module] = compile_to_path!([dep_file], Path.dirname(beam_path))
+      File.touch!(beam_path, {{2101, 1, 1}, {0, 0, 0}})
+
+      assert {after_compile, []} = update_index(project)
+
+      assert Enum.any?(
+               after_compile,
+               &(&1.subject == Forge.Formats.mfa(module, :newly_compiled_function, 0))
+             )
+
+      refute Enum.any?(after_compile, &(&1.subject == Forge.Formats.mfa(module, :public_fun, 0)))
     end
 
     @tag :tmp_dir


### PR DESCRIPTION
This is not really visible in current main, but I found it querying the index while working on Call Hierarchy

Basically we were missing some index entries for dependencies if the .beam file for them was older than the last modified date for the source file that produced it, so we skipped that beam due to it being stale.

The idea behind that check was to not point to incorrect source locations if the dependency is a path dependency(like `forge` in the expert poncho project) and source files changed, but it turns out to not be a good check. If the beam file is stale then we should wait for Expert to recompile everything, dependency included, instead of trying to be smart in the indexer and accidentally missing results.