### PR TITLE
feat: implement call hierarchy

### DIFF
--- a/apps/engine/lib/engine/search/indexer/extractors/function_definition.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/function_definition.ex
@@ -8,9 +8,10 @@ defmodule Engine.Search.Indexer.Extractors.FunctionDefinition do
 
   @function_definitions [:def, :defp, :defmacro, :defmacrop]
 
-  def extract({definition, _, [{fn_name, _, args} = def_ast, body]} = ast, %Reducer{} = reducer)
+  def extract({definition, _, [{fn_name, _, _} = def_ast | body]} = ast, %Reducer{} = reducer)
       when is_atom(fn_name) and definition in @function_definitions do
     with {:ok, detail_range} <- Ast.Range.fetch(def_ast, reducer.analysis.document),
+         true <- valid_bodyless_head?(body, reducer.analysis, detail_range),
          {:ok, module} <- Analyzer.current_module(reducer.analysis, detail_range.start),
          {fun_name, arity} when is_atom(fun_name) <- fun_name_and_arity(def_ast) do
       min_arity = arity - count_defaults(extract_args(def_ast))
@@ -31,7 +32,13 @@ defmodule Engine.Search.Indexer.Extractors.FunctionDefinition do
           )
         end
 
-      {:ok, entries, [args, body]}
+      args_and_guards =
+        case def_ast do
+          {:when, _, [{_, _, args} | guards]} -> [args | guards]
+          {_, _, args} -> args
+        end
+
+      {:ok, entries, [args_and_guards, body]}
     else
       _ ->
         :ignored
@@ -104,6 +111,14 @@ defmodule Engine.Search.Indexer.Extractors.FunctionDefinition do
 
   defp extract_args({:when, _, [{_fun_name, _, fun_args} | _]}), do: fun_args || []
   defp extract_args({_fun_name, _, fun_args}), do: fun_args || []
+
+  defp valid_bodyless_head?([], %Analysis{valid?: false, document: document}, range) do
+    # Partial AST can make `def run(arg do ... end` look like a bodyless declaration.
+    source = Forge.Document.fragment(document, range.start, range.end)
+    match?({:ok, _}, Code.string_to_quoted(source))
+  end
+
+  defp valid_bodyless_head?(_body, _analysis, _range), do: true
 
   defp count_defaults(args) do
     Enum.count(args, &match?({:\\, _, _}, &1))

--- a/apps/engine/lib/engine/search/indexer/extractors/function_reference.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/function_reference.ex
@@ -100,24 +100,27 @@ defmodule Engine.Search.Indexer.Extractors.FunctionReference do
     {:ok, nil, new_pipe}
   end
 
-  def extract({:defdelegate, _, _} = ast, %Reducer{} = reducer) do
+  def extract({:defdelegate, _, [call, _]} = ast, %Reducer{} = reducer) do
     analysis = reducer.analysis
     position = Reducer.position(reducer)
 
-    case FunctionDefinition.fetch_delegated_mfa(ast, analysis, position) do
-      {:ok, {module, function_name, arity}} ->
-        entry =
-          Entry.reference(
-            analysis.document.path,
-            Reducer.current_block(reducer),
-            Forge.Formats.mfa(module, function_name, arity),
-            {:function, :usage},
-            Ast.Range.get(ast, analysis.document),
-            Engine.ApplicationCache.application(module)
-          )
+    with {:ok, {module, function_name, arity}} <-
+           FunctionDefinition.fetch_delegated_mfa(ast, analysis, position),
+         {:ok, caller_module} <- Engine.Analyzer.current_module(analysis, position) do
+      {caller_name, args} = Macro.decompose_call(call)
 
-        {:ok, entry, []}
+      entry =
+        Entry.reference(
+          analysis.document.path,
+          Reducer.current_block(reducer),
+          Forge.Formats.mfa(module, function_name, arity),
+          {:function, :usage},
+          Ast.Range.get(ast, analysis.document),
+          Engine.ApplicationCache.application(module)
+        )
 
+      {:ok, %{entry | caller: Subject.mfa(caller_module, caller_name, length(args))}, []}
+    else
       _ ->
         :ignored
     end
@@ -275,7 +278,7 @@ defmodule Engine.Search.Indexer.Extractors.FunctionReference do
 
     # syntax specific functions to exclude from our matches
     excluded_operators =
-      ~w[<- -> && ** ++ -- .. "..//" ! <> =~ @ |> | || * + - / != !== < <= == === > >=]a
+      ~W[\\ <- -> && ** ++ -- .. "..//" ! <> =~ @ |> | || * + - / != !== < <= == === > >=]a
 
     excluded_keywords = ~w[and if import in not or raise require try use]a
 

--- a/apps/engine/lib/engine/search/indexer/extractors/module.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/module.ex
@@ -54,6 +54,14 @@ defmodule Engine.Search.Indexer.Extractors.Module do
     end
   end
 
+  # Keyword-do syntax puts `for:` and `do:` in one list; split them for the extractor below.
+  def extract(
+        {:defimpl, metadata, [protocol, [for_block, {{:__block__, _, [:do]}, _} = body]]},
+        %Reducer{} = reducer
+      ) do
+    extract({:defimpl, metadata, [protocol, [for_block], [body]]}, reducer)
+  end
+
   # defimpl MyProtocol, for: MyStruct do ...
   def extract(
         {:defimpl, _, [{:__aliases__, _, module_name}, [for_block], _impl_body]} = defimpl_ast,
@@ -217,7 +225,19 @@ defmodule Engine.Search.Indexer.Extractors.Module do
         {:ok, range}
 
       nil ->
-        :error
+        case protocol_ast do
+          {:defimpl, _, [_, _, [{{:__block__, do_meta, [:do]}, _}]]} ->
+            document = reducer.analysis.document
+
+            {:ok,
+             Range.new(
+               Position.new(document, start[:line], start[:column]),
+               Position.new(document, do_meta[:line], do_meta[:column] + 3)
+             )}
+
+          _ ->
+            :error
+        end
     end
   end
 

--- a/apps/engine/lib/engine/search/indexer/extractors/module_attribute.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/module_attribute.ex
@@ -42,7 +42,7 @@ defmodule Engine.Search.Indexer.Extractors.ModuleAttribute do
   end
 
   # Finds module attribute definitions @foo 3
-  def extract({:@, _, [{attr_name, _, _attr_value}]} = attr, %Reducer{} = reducer) do
+  def extract({:@, _, [{attr_name, _, attr_value}]} = attr, %Reducer{} = reducer) do
     block = Reducer.current_block(reducer)
 
     case Analyzer.current_module(reducer.analysis, Reducer.position(reducer)) do
@@ -57,7 +57,20 @@ defmodule Engine.Search.Indexer.Extractors.ModuleAttribute do
             Engine.ApplicationCache.application(current_module)
           )
 
-        {:ok, definition}
+        value =
+          if attr_name in [:spec, :type, :typep, :opaque, :callback, :macrocallback] do
+            Macro.prewalk(attr_value, fn
+              {name, meta, args} when name not in [:__aliases__, :__MODULE__, :__block__] ->
+                {name, Reducer.skip(meta), args}
+
+              ast ->
+                ast
+            end)
+          else
+            attr_value
+          end
+
+        {:ok, definition, value}
 
       _ ->
         :ignored

--- a/apps/engine/lib/engine/search/indexer/metadata.ex
+++ b/apps/engine/lib/engine/search/indexer/metadata.ex
@@ -9,7 +9,7 @@ defmodule Engine.Search.Indexer.Metadata do
       block_end = position(metadata, :end_of_expression) || position(metadata, :end)
       {:block, position, block_start, block_end}
     else
-      maybe_handle_terse_function(ast)
+      maybe_handle_terse_block(ast)
     end
   end
 
@@ -36,18 +36,25 @@ defmodule Engine.Search.Indexer.Metadata do
     |> position()
   end
 
-  @defines [:def, :defp, :defmacro, :defmacrop, :fn]
-  # a terse function is one without a do/end block
-  defp maybe_handle_terse_function({define, metadata, [_name_and_args | [[block | _]]]})
+  @defines [:def, :defp, :defmacro, :defmacrop, :fn, :defmodule, :defprotocol]
+  defp maybe_handle_terse_block(
+         {:defimpl, metadata, [_, [_, {{:__block__, _, [:do]}, _} = block]]}
+       ) do
+    block_location(block, metadata)
+  end
+
+  # def foo(), do: :ok or defmodule Foo, do: :ok
+  defp maybe_handle_terse_block({define, metadata, [_name_and_args | [[block | _]]]})
        when define in @defines do
     block_location(block, metadata)
   end
 
-  defp maybe_handle_terse_function({:fn, metadata, _} = ast) do
+  defp maybe_handle_terse_block({define, metadata, _} = ast)
+       when define in @defines do
     block_location(ast, metadata)
   end
 
-  defp maybe_handle_terse_function({_, metadata, _}) do
+  defp maybe_handle_terse_block({_, metadata, _}) do
     {:expression, position(metadata)}
   end
 

--- a/apps/engine/lib/engine/search/indexer/source/reducer.ex
+++ b/apps/engine/lib/engine/search/indexer/source/reducer.ex
@@ -29,7 +29,8 @@ defmodule Engine.Search.Indexer.Source.Reducer do
     %__MODULE__{
       analysis: analysis,
       block_hierarchy: %{root: %{}},
-      blocks: [Block.root()],
+      # Top-level calls belong to the source file.
+      blocks: [%{Block.root() | caller: analysis.document.path}],
       entries: [],
       extractors: extractors || @extractors,
       position: {0, 0}
@@ -124,7 +125,7 @@ defmodule Engine.Search.Indexer.Source.Reducer do
 
   defp push_block(%__MODULE__{} = reducer, %Block{} = block) do
     parent = current_block(reducer)
-    block = %Block{block | parent_id: parent.id}
+    block = %Block{block | parent_id: parent.id, caller: parent.caller}
     id_path = Enum.reduce(reducer.blocks, [], fn block, acc -> [block.id | acc] end)
 
     hierarchy =
@@ -170,10 +171,37 @@ defmodule Engine.Search.Indexer.Source.Reducer do
   end
 
   defp push_entry(%__MODULE__{} = reducer, %Entry{} = entry) do
+    reducer =
+      case entry do
+        %Entry{subtype: :definition, type: {kind, visibility}}
+        when kind in [:function, :macro] and visibility in [:public, :private] ->
+          put_caller(reducer, entry.subject)
+
+        %Entry{subtype: :definition, type: type}
+        when type in [:module, {:protocol, :definition}, {:protocol, :implementation}] ->
+          put_caller(reducer, Forge.Formats.module(entry.subject))
+
+        _ ->
+          reducer
+      end
+
+    entry =
+      case entry do
+        %Entry{subtype: :reference, type: {:function, :usage}, caller: nil} ->
+          %{entry | caller: current_block(reducer).caller}
+
+        _ ->
+          entry
+      end
+
     %__MODULE__{reducer | entries: [entry | reducer.entries]}
   end
 
   defp push_entry(%__MODULE__{} = reducer, _), do: reducer
+
+  defp put_caller(%__MODULE__{blocks: [block | rest]} = reducer, caller) do
+    %{reducer | blocks: [%{block | caller: caller} | rest]}
+  end
 
   defp maybe_pop_block(%__MODULE__{} = reducer) do
     if block_ended?(reducer) do

--- a/apps/engine/test/engine/code_intelligence/symbols_test.exs
+++ b/apps/engine/test/engine/code_intelligence/symbols_test.exs
@@ -569,6 +569,27 @@ defmodule Engine.CodeIntelligence.SymbolsTest do
       assert function.children == []
     end
 
+    test "preserves bodyless default headers in a partial AST" do
+      {[module], doc} =
+        ~q[
+        defmodule MyModule do
+          def valid_function(arg \\ :default)
+
+          def broken_function(arg do
+            :error
+          end
+        end
+        ]
+        |> document_symbols()
+
+      assert [zero_arity, one_arity] = module.children
+      assert zero_arity.subject == "MyModule.valid_function/0"
+      assert one_arity.subject == "MyModule.valid_function/1"
+      assert zero_arity.type == {:function, :public}
+      assert one_arity.type == {:function, :public}
+      assert extract(doc, one_arity.detail_range) == ~S"valid_function(arg \\ :default)"
+    end
+
     test "returns symbols for invalid code with module attributes" do
       {symbols, doc} =
         ~q[
@@ -756,7 +777,7 @@ defmodule Engine.CodeIntelligence.SymbolsTest do
       assert function.name == "SomeProtocol.Atom.do_stuff/2"
     end
 
-    test "converts protocol definitions" do
+    test "converts bodyless protocol declarations to public function symbols" do
       {[protocol, function], _doc, _uri} =
         ~q[
           defprotocol MyProto do
@@ -768,7 +789,7 @@ defmodule Engine.CodeIntelligence.SymbolsTest do
       assert protocol.type == {:protocol, :definition}
       assert protocol.name == "MyProto"
 
-      assert function.type == {:function, :usage}
+      assert function.type == {:function, :public}
       assert function.name == "MyProto.do_stuff/2"
     end
   end

--- a/apps/engine/test/engine/search/indexer/extractors/function_reference_test.exs
+++ b/apps/engine/test/engine/search/indexer/extractors/function_reference_test.exs
@@ -184,6 +184,26 @@ defmodule Engine.Search.Indexer.Extractors.FunctionReferenceTest do
   end
 
   describe "local function references" do
+    test "finds calls in defaults, guards, and the body of a guarded definition" do
+      code = ~q[
+        defmodule Parent do
+          def run(value \\ default()) when is_binary(value), do: process(value)
+
+          defp default(), do: :ok
+
+          defp process(value), do: value
+        end
+      ]
+
+      assert {:ok, [default, guard, body], document} = index(code)
+      assert default.subject == "Parent.default/0"
+      assert guard.subject == "Kernel.is_binary/1"
+      assert body.subject == "Parent.process/1"
+      assert extract(document, default.range) == "default()"
+      assert extract(document, guard.range) == "is_binary(value)"
+      assert extract(document, body.range) == "process(value)"
+    end
+
     test "finds a zero-arg local function on the right of a match" do
       code = in_a_module_function("x = local()")
       {:ok, [reference], _} = index(code)

--- a/apps/engine/test/engine/search/indexer/extractors/module_attribute_test.exs
+++ b/apps/engine/test/engine/search/indexer/extractors/module_attribute_test.exs
@@ -10,6 +10,63 @@ defmodule Engine.Search.Indexer.Extractors.ModuleAttributeTest do
   end
 
   describe "indexing module attributes" do
+    test "initializers retain real calls without indexing the attribute name as a call" do
+      source = ~q"""
+      defmodule Owner do
+        @compiled Target.prepare(Target.input())
+        @mapped Enum.map([], fn value -> Target.map(value) end)
+        Target.after_attributes()
+      end
+      """
+
+      assert {:ok, entries, _} = index_everything(source)
+      calls = Enum.filter(entries, &(&1.type == {:function, :usage}))
+
+      assert Enum.map(calls, &{&1.subject, &1.caller}) == [
+               {"Target.prepare/1", "Owner"},
+               {"Target.input/0", "Owner"},
+               {"Enum.map/2", "Owner"},
+               {"Target.map/1", "Owner"},
+               {"Target.after_attributes/0", "Owner"}
+             ]
+
+      attributes = Enum.filter(entries, &(&1.type == :module_attribute))
+      assert Enum.map(attributes, & &1.subject) == ["@compiled", "@mapped"]
+    end
+
+    test "typespec signatures are not runtime calls but retain module references" do
+      source = ~q[
+      defmodule Owner do
+        @spec run(Input.t()) :: Output.t()
+        @type item() :: Item.t()
+        @typep private_item() :: PrivateItem.t()
+        @opaque secret() :: Secret.t()
+        @callback handle(Request.t()) :: Response.t()
+        @macrocallback build(MacroInput.t()) :: MacroOutput.t()
+        Target.after_signatures()
+      end
+      ]
+
+      assert {:ok, entries, _} = index_everything(source)
+      calls = Enum.filter(entries, &(&1.type == {:function, :usage}))
+      assert Enum.map(calls, &{&1.subject, &1.caller}) == [{"Target.after_signatures/0", "Owner"}]
+
+      modules = Enum.filter(entries, &(&1.type == :module and &1.subtype == :reference))
+
+      assert Enum.map(modules, & &1.subject) == [
+               Input,
+               Output,
+               Item,
+               PrivateItem,
+               Secret,
+               Request,
+               Response,
+               MacroInput,
+               MacroOutput,
+               Target
+             ]
+    end
+
     test "finds definitions when defining scalars" do
       {:ok, [attr], doc} =
         ~q[

--- a/apps/engine/test/engine/search/indexer/extractors/protocol_test.exs
+++ b/apps/engine/test/engine/search/indexer/extractors/protocol_test.exs
@@ -31,6 +31,27 @@ defmodule Engine.Search.Indexer.Extractors.ProtocolTest do
   end
 
   describe "indexing protocol implementations" do
+    test "keyword-do implementations have declaration and block ranges without the following expression" do
+      source = ~q[
+      defimpl Action, for: Atom, do: Target.run(); Target.after_implementation()
+      ]
+
+      assert {:ok, entries, document} = index_everything(source)
+      definitions = Enum.filter(entries, &(&1.subtype == :definition))
+      assert [implementation, module] = definitions
+      assert implementation.type == {:protocol, :implementation}
+      assert implementation.subject == Action
+      assert module.type == :module
+      assert module.subject == Action.Atom
+      assert extract(document, implementation.range) == "defimpl Action, for: Atom, do:"
+
+      assert extract(document, implementation.block_range) ==
+               "defimpl Action, for: Atom, do: Target.run()"
+
+      assert module.range == implementation.range
+      assert module.block_range == implementation.block_range
+    end
+
     test "works" do
       {:ok, [protocol], doc} =
         ~q[

--- a/apps/engine/test/engine/search/indexer/metadata_test.exs
+++ b/apps/engine/test/engine/search/indexer/metadata_test.exs
@@ -11,6 +11,12 @@ defmodule Engine.Search.Indexer.MetadataTest do
   alias Forge.Document.Range
 
   describe "blocks in modules" do
+    test "finds the body rather than the target of a keyword-do implementation" do
+      code = "defimpl Action, for: Atom, do: Target.run()"
+
+      assert "defimpl Action, for: Atom, «do: Target.run()»" == decorate_location(code)
+    end
+
     test "finds a block in an empty module" do
       code = ~q[
         defmodule MyModule do

--- a/apps/engine/test/engine/search/indexer/structure_test.exs
+++ b/apps/engine/test/engine/search/indexer/structure_test.exs
@@ -1,6 +1,8 @@
 defmodule Engine.Search.Indexer.StructureTest do
   use Engine.Test.ExtractorCase
 
+  alias Forge.Search.Indexer.Entry
+
   def index(source) do
     case do_index(source, fn entry -> entry.type != :metadata end) do
       {:ok, results, _doc} -> {:ok, results}
@@ -50,5 +52,347 @@ defmodule Engine.Search.Indexer.StructureTest do
       assert first_call.block_id == :root
       assert last_call.block_id == :root
     end
+  end
+
+  describe "callers are correctly identified" do
+    setup do
+      {:ok, file_path: Forge.Document.new("/foo/bar/baz.ex", "", 0).path}
+    end
+
+    test "when inside a function" do
+      {:ok, results} =
+        ~q[
+        defmodule Orders do
+          def checkout(cart) do
+            Payments.charge(cart)
+
+            if cart.valid? do
+              Payments.charge(cart)
+            end
+          end
+
+          def retry(cart) do
+            Payments.charge(cart)
+          end
+
+          Payments.charge(:example)
+        end
+        ]
+        |> index()
+
+      refs =
+        Enum.filter(results, fn %Entry{} = entry ->
+          entry.subject == "Payments.charge/1" and entry.subtype == :reference
+        end)
+
+      assert Enum.map(refs, & &1.caller) == [
+               "Orders.checkout/1",
+               "Orders.checkout/1",
+               "Orders.retry/1",
+               "Orders"
+             ]
+    end
+
+    test "file callers are restored before, between, and after modules", %{file_path: file_path} do
+      {:ok, results} =
+        ~q[
+        Target.before_modules()
+
+        defmodule Outer do
+          Target.outer()
+
+          defmodule Inner do
+            Target.inner()
+          end
+
+          Target.outer_again()
+        end
+
+        Target.between_modules()
+
+        defmodule Sibling do
+          Target.sibling()
+        end
+
+        Target.after_modules()
+        ]
+        |> index()
+
+      assert callers(results) == [
+               {"Target.before_modules/0", file_path},
+               {"Target.outer/0", "Outer"},
+               {"Target.inner/0", "Outer.Inner"},
+               {"Target.outer_again/0", "Outer"},
+               {"Target.between_modules/0", file_path},
+               {"Target.sibling/0", "Sibling"},
+               {"Target.after_modules/0", file_path}
+             ]
+
+      modules = Enum.filter(results, &(&1.type == :module and &1.subtype == :definition))
+      assert Enum.map(modules, & &1.subject) == [Outer, Outer.Inner, Sibling]
+    end
+
+    test "scripts without modules use the document path through nested blocks" do
+      source = ~q"""
+      Target.before_block()
+
+      if true do
+        Enum.each([], fn item -> Target.item(item) end)
+      end
+
+      Target.after_block()
+      """
+
+      document = Forge.Document.new("/project/build.exs", source, 0)
+      assert {:ok, results} = Engine.Search.Indexer.Source.index(document.path, source)
+
+      assert callers(results) == [
+               {"Target.before_block/0", document.path},
+               {"Enum.each/2", document.path},
+               {"Target.item/1", document.path},
+               {"Target.after_block/0", document.path}
+             ]
+    end
+
+    test "keyword-do modules restore the parent and file callers on the same line", %{
+      file_path: file_path
+    } do
+      {:ok, results} =
+        ~q[
+        defmodule Outer do
+          defmodule Inner, do: Target.inner(); Target.outer()
+        end
+
+        defmodule Sibling, do: Target.sibling(); Target.file()
+        ]
+        |> index()
+
+      assert callers(results) == [
+               {"Target.inner/0", "Outer.Inner"},
+               {"Target.outer/0", "Outer"},
+               {"Target.sibling/0", "Sibling"},
+               {"Target.file/0", file_path}
+             ]
+    end
+
+    test "private functions and macros own calls while ordinary blocks inherit callers" do
+      {:ok, results} =
+        ~q[
+        defmodule Owner do
+          if true do
+            Target.module_block()
+          end
+
+          defp private_call(), do: Target.private_call()
+
+          defmacro public_macro do
+            fn -> Target.macro_block() end
+          end
+
+          defmacrop private_macro(), do: Target.private_macro()
+
+          Target.module_body()
+        end
+        ]
+        |> index()
+
+      assert callers(results) == [
+               {"Target.module_block/0", "Owner"},
+               {"Target.private_call/0", "Owner.private_call/0"},
+               {"Target.macro_block/0", "Owner.public_macro/0"},
+               {"Target.private_macro/0", "Owner.private_macro/0"},
+               {"Target.module_body/0", "Owner"}
+             ]
+    end
+
+    test "bodyless default headers own defaults without indexing the head as a call" do
+      {:ok, results} =
+        ~q[
+        defmodule Owner do
+          def run(value \\ Target.default())
+
+          Target.after_header()
+
+          def run(value) when is_binary(value), do: Target.run(value)
+
+          Target.after_function()
+        end
+        ]
+        |> index()
+
+      assert callers(results) == [
+               {"Target.default/0", "Owner.run/1"},
+               {"Target.after_header/0", "Owner"},
+               {"Kernel.is_binary/1", "Owner.run/1"},
+               {"Target.run/1", "Owner.run/1"},
+               {"Target.after_function/0", "Owner"}
+             ]
+
+      definitions = Enum.filter(results, &(&1.type == {:function, :public}))
+      assert Enum.map(definitions, & &1.subject) == ["Owner.run/0", "Owner.run/1", "Owner.run/1"]
+    end
+
+    test "defaults in function and macro bodies use the full callable arity" do
+      {:ok, results} =
+        ~q[
+        defmodule Owner do
+          def run(value \\ Target.default()), do: Target.run(value)
+
+          defmacro build(value \\ Target.macro_default()) do
+            Target.build(value)
+          end
+
+          Target.module_body()
+        end
+        ]
+        |> index()
+
+      assert callers(results) == [
+               {"Target.default/0", "Owner.run/1"},
+               {"Target.run/1", "Owner.run/1"},
+               {"Target.macro_default/0", "Owner.build/1"},
+               {"Target.build/1", "Owner.build/1"},
+               {"Target.module_body/0", "Owner"}
+             ]
+    end
+
+    test "delegates retain their explicit caller without changing the module caller", %{
+      file_path: file_path
+    } do
+      {:ok, results} =
+        ~q[
+        defmodule Owner do
+          Target.before_delegate()
+
+          defdelegate trim(value), to: String
+
+          Target.after_delegate()
+        end
+
+        Target.file()
+        ]
+        |> index()
+
+      assert callers(results) == [
+               {"Target.before_delegate/0", "Owner"},
+               {"String.trim/1", "Owner.trim/1"},
+               {"Target.after_delegate/0", "Owner"},
+               {"Target.file/0", file_path}
+             ]
+    end
+
+    test "protocol and implementation bodies use their actual owning module", %{
+      file_path: file_path
+    } do
+      {:ok, results} =
+        ~q[
+        defprotocol Action do
+          Target.protocol_body()
+
+          def run(value)
+
+          Target.after_header()
+        end
+
+        Target.between_declarations()
+
+        defimpl Action, for: Atom do
+          Target.implementation_body()
+
+          def run(value), do: Target.run(value)
+
+          Target.after_function()
+        end
+
+        Target.file()
+        ]
+        |> index()
+
+      assert callers(results) == [
+               {"Target.protocol_body/0", "Action"},
+               {"Target.after_header/0", "Action"},
+               {"Target.between_declarations/0", file_path},
+               {"Target.implementation_body/0", "Action.Atom"},
+               {"Target.run/1", "Action.Atom.run/1"},
+               {"Target.after_function/0", "Action.Atom"},
+               {"Target.file/0", file_path}
+             ]
+
+      assert Enum.any?(results, &(&1.type == :module and &1.subject == Action.Atom))
+    end
+
+    test "keyword-do protocol boundaries restore file callers", %{file_path: file_path} do
+      {:ok, results} =
+        ~q[
+        defprotocol Action, do: Target.protocol_body(); Target.after_protocol()
+        ]
+        |> index()
+
+      assert callers(results) == [
+               {"Target.protocol_body/0", "Action"},
+               {"Target.after_protocol/0", file_path}
+             ]
+    end
+
+    test "keyword-do implementations own their calls and restore the file caller on the same line",
+         %{
+           file_path: file_path
+         } do
+      {:ok, results} =
+        ~q[
+        Target.before_implementation()
+
+        defimpl Action, for: Atom, do: Target.implementation(); Target.after_implementation()
+        ]
+        |> index()
+
+      assert callers(results) == [
+               {"Target.before_implementation/0", file_path},
+               {"Target.implementation/0", "Action.Atom"},
+               {"Target.after_implementation/0", file_path}
+             ]
+    end
+
+    test "keyword-do implementations resolve aliases and restore the enclosing module caller", %{
+      file_path: file_path
+    } do
+      {:ok, results} =
+        ~q[
+        defmodule Outer do
+          alias Example.Action
+          alias Example.Record
+
+          defimpl Action, for: Record, do: (
+            Target.implementation()
+            def run(value), do: Target.run(value)
+            Target.after_function()
+          )
+
+          Target.outer()
+        end
+
+        Target.file()
+        ]
+        |> index()
+
+      assert callers(results) == [
+               {"Target.implementation/0", "Example.Action.Example.Record"},
+               {"Target.run/1", "Example.Action.Example.Record.run/1"},
+               {"Target.after_function/0", "Example.Action.Example.Record"},
+               {"Target.outer/0", "Outer"},
+               {"Target.file/0", file_path}
+             ]
+
+      assert Enum.any?(
+               results,
+               &(&1.type == :module and &1.subject == Example.Action.Example.Record)
+             )
+    end
+  end
+
+  defp callers(results) do
+    results
+    |> Enum.filter(&(&1.type == {:function, :usage} and &1.subtype == :reference))
+    |> Enum.map(&{&1.subject, &1.caller})
   end
 end

--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -135,6 +135,13 @@ defmodule Expert do
            message: "Document could not be loaded"
          }, lsp}
 
+      {:error, :invalid_call_hierarchy_item} ->
+        {:reply,
+         %GenLSP.ErrorResponse{
+           code: GenLSP.Enumerations.ErrorCodes.invalid_params(),
+           message: "Call hierarchy item has missing or unknown project context"
+         }, lsp}
+
       error ->
         message = "Failed to handle #{request.method}, #{inspect(error)}"
         Logger.error(message)
@@ -165,6 +172,9 @@ defmodule Expert do
       {:ok, nil}
     end
   end
+
+  defp document_request?(%{item: %GenLSP.Structures.CallHierarchyItem{uri: uri}})
+       when is_binary(uri), do: true
 
   defp document_request?(%{document: %Forge.Document{}}), do: true
 
@@ -559,6 +569,15 @@ defmodule Expert do
 
       %GenLSP.Requests.WorkspaceSymbol{} ->
         {:ok, Handlers.WorkspaceSymbol}
+
+      %GenLSP.Requests.TextDocumentPrepareCallHierarchy{} ->
+        {:ok, Handlers.CallHierarchy}
+
+      %GenLSP.Requests.CallHierarchyIncomingCalls{} ->
+        {:ok, Handlers.CallHierarchy}
+
+      %GenLSP.Requests.CallHierarchyOutgoingCalls{} ->
+        {:ok, Handlers.CallHierarchy}
 
       %request_module{} ->
         {:error, {:unhandled, request_module}}

--- a/apps/expert/lib/expert/document/lookup.ex
+++ b/apps/expert/lib/expert/document/lookup.ex
@@ -41,7 +41,33 @@ defmodule Expert.Document.Lookup do
   end
 
   @spec resolve_from_request(struct(), [Project.t()]) ::
-          {:ok, Context.t()} | {:error, :document_not_found}
+          {:ok, Context.t()}
+          | {:error, :document_not_found}
+          | {:error, :invalid_call_hierarchy_item}
+  def resolve_from_request(
+        %request_module{
+          params: %{item: %Structures.CallHierarchyItem{} = item}
+        } = request,
+        projects
+      )
+      when request_module in [
+             GenLSP.Requests.CallHierarchyIncomingCalls,
+             GenLSP.Requests.CallHierarchyOutgoingCalls
+           ] do
+    # For path dependencies in poncho projects, call hierarchy items will point to
+    # a path in a different project. This will stop Call Hierarchy from working
+    # properly, as requests to it will be handled by the dependency project instead
+    # of the project that actually initiated the requests.
+    with %{"project_root_uri" => root_uri} when is_binary(root_uri) <- item.data,
+         %Project{} = project <- Enum.find(projects, &(&1.root_uri == root_uri)),
+         {:ok, %Document{} = document} <- request_document(request) do
+      {:ok, Context.new(document.uri, document, project)}
+    else
+      {:error, _} = error -> error
+      _ -> {:error, :invalid_call_hierarchy_item}
+    end
+  end
+
   def resolve_from_request(request_or_params, projects) when is_list(projects) do
     with {:ok, %Document{} = document} <- request_document(request_or_params) do
       {:ok, resolve(document, projects)}
@@ -278,6 +304,9 @@ defmodule Expert.Document.Lookup do
       Document.Store.open_temporary(uri)
     end
   end
+
+  defp extract_uri(%{item: %GenLSP.Structures.CallHierarchyItem{uri: uri}}) when is_binary(uri),
+    do: uri
 
   defp extract_uri(%{text_document: %{uri: uri}}) when is_binary(uri), do: uri
   defp extract_uri(%{uri: uri}) when is_binary(uri), do: uri

--- a/apps/expert/lib/expert/provider/handlers/call_hierarchy.ex
+++ b/apps/expert/lib/expert/provider/handlers/call_hierarchy.ex
@@ -1,0 +1,259 @@
+defmodule Expert.Provider.Handlers.CallHierarchy do
+  @moduledoc """
+  Call Hierarchy requires 3 handlers:
+
+  - Prepare: called with the cursor location where the user requested the Call Hierarchy.
+    This is always called first, it resolves the function under the cursor and hands it to
+    the client. The client then sends this item back as the payload for the incoming/outgoing
+    calls requests.
+  - Incoming calls: returns the places that call a function.
+  - Outgoing calls: returns the functions called by the selected function.
+
+  Calls outside functions are represented by module or file caller items. These are terminal
+  locations: incoming and outgoing requests for them return no calls.
+
+  To form the hierarchy tree in the UI, the client sends a request for incoming/outgoing calls
+  one item at a time. In practice, it means the call hierarchy is resolved as the user expands
+  each item in their UI.
+  """
+  @behaviour Expert.Provider.Handler
+
+  import Forge.Document.Line, only: [line: 1]
+
+  alias Expert.Document.Context
+  alias Forge.Ast
+  alias Forge.Document
+  alias Forge.Document.Position
+  alias Forge.Document.Range
+  alias Forge.Formats
+  alias Forge.Project
+  alias Forge.Search.Indexer.Entry
+  alias GenLSP.Enumerations.SymbolKind
+  alias GenLSP.Requests
+  alias GenLSP.Structures
+
+  @function_kind SymbolKind.function()
+
+  @impl Expert.Provider.Handler
+  def handle(
+        %Requests.TextDocumentPrepareCallHierarchy{
+          params: %Structures.CallHierarchyPrepareParams{} = params
+        },
+        %Context{} = context
+      ) do
+    %Context{document: document, project: project} = context
+
+    with {:ok, _document, %Ast.Analysis{} = analysis} <-
+           Document.Store.fetch(document.uri, :analysis),
+         {:ok, {:call, module, function, arity}, _range} <-
+           Expert.EngineApi.resolve_entity(project, analysis, params.position) do
+      mfa = Formats.mfa(module, function, arity)
+
+      case Expert.Search.Store.exact(project, mfa, subtype: :definition) do
+        {:ok, [definition | _]} -> {:ok, [build_call_item(definition, project)]}
+        _ -> {:ok, []}
+      end
+    else
+      _ ->
+        {:ok, []}
+    end
+  end
+
+  def handle(
+        %request{params: %{item: %{kind: kind}}},
+        %Context{}
+      )
+      when request in [Requests.CallHierarchyIncomingCalls, Requests.CallHierarchyOutgoingCalls] and
+             kind != @function_kind do
+    {:ok, []}
+  end
+
+  def handle(
+        %Requests.CallHierarchyIncomingCalls{
+          params: %Structures.CallHierarchyIncomingCallsParams{} = params
+        },
+        %Context{} = context
+      ) do
+    %Context{project: project} = context
+    item = params.item
+
+    with {:ok, references} <-
+           Expert.Search.Store.exact(project, item.name,
+             type: {:function, :usage},
+             subtype: :reference
+           ),
+         references_by_caller =
+           references
+           |> Enum.reject(&is_nil(&1.caller))
+           |> Enum.group_by(&{&1.path, &1.caller}),
+         subjects =
+           for({{path, caller}, _references} <- references_by_caller, caller != path, do: caller),
+         {:ok, definitions} <-
+           Expert.Search.Store.exact_many(project, subjects, subtype: :definition) do
+      definitions_by_caller = Enum.group_by(definitions, &{&1.path, format_subject(&1.subject)})
+
+      incoming_calls =
+        for {key, references} <- references_by_caller,
+            {:ok, caller} <- [caller_item(key, definitions_by_caller, project)] do
+          %Structures.CallHierarchyIncomingCall{
+            from: caller,
+            from_ranges: for(reference <- references, do: reference.range)
+          }
+        end
+
+      {:ok, incoming_calls}
+    else
+      {:error, _} = error ->
+        error
+
+      _ ->
+        {:ok, []}
+    end
+  end
+
+  def handle(
+        %Requests.CallHierarchyOutgoingCalls{
+          params: %Structures.CallHierarchyOutgoingCallsParams{} = params
+        },
+        %Context{} = context
+      ) do
+    %Context{document: document, project: project} = context
+    item = params.item
+
+    with {:ok, definitions} <- Expert.Search.Store.exact(project, item.name, subtype: :definition),
+         %Entry{} = definition <- Enum.find(definitions, &(&1.path == document.path)),
+         caller = caller_subject(definition, document),
+         {:ok, references} <-
+           Expert.Search.Store.by_caller(project, caller, document.path,
+             type: {:function, :usage},
+             subtype: :reference
+           ),
+         references_by_callee = Enum.group_by(references, & &1.subject),
+         subjects = Map.keys(references_by_callee),
+         {:ok, definitions} <-
+           Expert.Search.Store.exact_many(project, subjects, subtype: :definition) do
+      definitions_by_callee = Enum.group_by(definitions, &{&1.path, &1.subject})
+
+      # We only use the first definition clause for the item range
+      outgoing_calls =
+        Enum.map(definitions_by_callee, fn {{_path, subject}, [clause | _]} ->
+          references = Map.fetch!(references_by_callee, subject)
+
+          %Structures.CallHierarchyOutgoingCall{
+            to: build_call_item(clause, project),
+            from_ranges: for(reference <- references, uniq: true, do: reference.range)
+          }
+        end)
+
+      {:ok, outgoing_calls}
+    else
+      {:error, _} = error ->
+        error
+
+      _ ->
+        {:ok, []}
+    end
+  end
+
+  defp caller_item({path, caller}, _definitions, project) when path == caller do
+    uri = Document.Path.to_uri(path)
+
+    result =
+      case Document.Store.fetch(uri) do
+        {:ok, document} -> {:ok, document}
+        {:error, :not_open} -> Document.Store.open_temporary(uri)
+      end
+
+    with {:ok, document} <- result do
+      {:ok, build_call_item(document, project)}
+    end
+  end
+
+  defp caller_item(key, definitions, project) do
+    with {:ok, [definition | _]} <- Map.fetch(definitions, key) do
+      {:ok, build_call_item(definition, project)}
+    end
+  end
+
+  # Functions with defaults produce with an arity lower than the total number of arguments
+  # For example this:
+  #
+  #     def foo(a \\ []), do: Enum.reverse(a)
+  #
+  # Produces foo/1 and foo/0. A call to `foo()` needs to point to this function, but the
+  # index contains only the entry for `foo/1`. This helper resolves that discrepancy.
+  defp caller_subject(%Entry{} = entry, %Document{} = document) do
+    case Ast.zipper_at(document, entry.range.start) do
+      {:ok, %{node: node}} -> subject_for_head(entry.subject, node)
+      _ -> entry.subject
+    end
+  end
+
+  defp subject_for_head(subject, {kind, _, [head | _]})
+       when kind in [:def, :defp, :defmacro, :defmacrop, :defdelegate, :when] do
+    subject_for_head(subject, head)
+  end
+
+  defp subject_for_head(subject, {name, _, args}) when is_atom(name) and is_list(args) do
+    {arity_text, name_parts} = subject |> String.split("/") |> List.pop_at(-1)
+    prefix = Enum.join(name_parts, "/") <> "/"
+    arity = length(args)
+    defaults = Enum.count(args, &match?({:\\, _, _}, &1))
+
+    with {requested_arity, ""} <- Integer.parse(arity_text),
+         true <- requested_arity in (arity - defaults)..arity do
+      prefix <> Integer.to_string(arity)
+    else
+      _ -> subject
+    end
+  end
+
+  defp subject_for_head(subject, _head), do: subject
+
+  defp build_call_item(%Entry{} = entry, %Project{} = project) do
+    %Structures.CallHierarchyItem{
+      name: format_subject(entry.subject),
+      kind: if(module_definition?(entry), do: SymbolKind.module(), else: SymbolKind.function()),
+      uri: Document.Path.to_uri(entry.path),
+      # Use the range for the entire entry, or its range if it has no body
+      # (defdelegates, function header with defaults, etc)
+      range: entry.block_range || entry.range,
+      selection_range: entry.range,
+      data: %{"project_root_uri" => project.root_uri}
+    }
+  end
+
+  defp build_call_item(%Document{} = document, %Project{} = project) do
+    start = Position.new(document, 1, 1)
+    last_line = Document.size(document)
+
+    # LSP range encloses the file; selection_range below is the navigation target.
+    finish =
+      case Document.fetch_line_at(document, last_line) do
+        {:ok, line(text: text, ending: "")} ->
+          Position.new(document, last_line, String.length(text) + 1)
+
+        {:ok, _line_with_ending} ->
+          Position.new(document, last_line + 1, 1)
+
+        :error ->
+          start
+      end
+
+    %Structures.CallHierarchyItem{
+      name: Path.basename(document.path),
+      kind: SymbolKind.file(),
+      uri: document.uri,
+      range: Range.new(start, finish),
+      selection_range: Range.new(start, start),
+      data: %{"project_root_uri" => project.root_uri}
+    }
+  end
+
+  defp format_subject(subject) when is_binary(subject), do: subject
+  defp format_subject(subject) when is_atom(subject), do: Formats.module(subject)
+
+  defp module_definition?(%Entry{type: :module}), do: true
+  defp module_definition?(%Entry{type: {:protocol, _}}), do: true
+  defp module_definition?(_entry), do: false
+end

--- a/apps/expert/lib/expert/search/store.ex
+++ b/apps/expert/lib/expert/search/store.ex
@@ -36,6 +36,19 @@ defmodule Expert.Search.Store do
     call_or_default(project, {:exact, subject, constraints}, [])
   end
 
+  @spec exact_many(Project.t(), [Entry.subject()], Entry.constraints()) ::
+          {:ok, [Entry.t()]} | {:error, term()} | []
+  def exact_many(%Project{} = project, subjects, constraints) when is_list(subjects) do
+    call_or_default(project, {:exact_many, subjects, constraints}, [])
+  end
+
+  @spec by_caller(Project.t(), Entry.caller(), Path.t(), Entry.constraints()) ::
+          {:ok, [Entry.t()]} | {:error, term()} | []
+  def by_caller(%Project{} = project, caller, path, constraints \\ [])
+      when is_binary(caller) and is_binary(path) do
+    call_or_default(project, {:by_caller, caller, path, constraints}, [])
+  end
+
   @spec prefix(Project.t(), String.t(), Entry.constraints()) ::
           {:ok, [Entry.t()]} | {:error, term()} | []
   def prefix(%Project{} = project, prefix, constraints) do
@@ -189,6 +202,20 @@ defmodule Expert.Search.Store do
   def handle_call({:exact, subject, constraints}, _from, {ref, %State{} = state}) do
     state
     |> State.exact(subject, constraints)
+    |> maybe_broadcast_loading(state)
+    |> then(&{:reply, &1, {ref, state}})
+  end
+
+  def handle_call({:exact_many, subjects, constraints}, _from, {ref, %State{} = state}) do
+    state
+    |> State.exact_many(subjects, constraints)
+    |> maybe_broadcast_loading(state)
+    |> then(&{:reply, &1, {ref, state}})
+  end
+
+  def handle_call({:by_caller, caller, path, constraints}, _from, {ref, %State{} = state}) do
+    state
+    |> State.by_caller(caller, path, constraints)
     |> maybe_broadcast_loading(state)
     |> then(&{:reply, &1, {ref, state}})
   end

--- a/apps/expert/lib/expert/search/store/backend.ex
+++ b/apps/expert/lib/expert/search/store/backend.ex
@@ -35,6 +35,10 @@ defmodule Expert.Search.Store.Backend do
                 Entry.t()
               ]
               | {:error, any()}
+  @callback find_by_subjects(Project.t(), [Entry.subject()], type_query(), subtype_query()) ::
+              [Entry.t()] | {:error, any()}
+  @callback find_by_caller(Project.t(), Entry.caller(), Path.t(), type_query(), subtype_query()) ::
+              [Entry.t()] | {:error, any()}
   @callback find_by_prefix(Project.t(), subject_query(), type_query(), subtype_query()) ::
               [
                 Entry.t()

--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -11,7 +11,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   require Entry
   require Logger
 
-  @schema_version 4
+  @schema_version 5
   @database_file "source.index.sqlite3"
   @slow_query_threshold_ms 500
   # NOTE(doorgan): SQLite has a variable limit of 32766. Entry batches use 7 params
@@ -98,6 +98,17 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   @impl Backend
   def find_by_subject(%Project{} = project, subject, type, subtype) do
     GenServer.call(name(project), {:find_by_subject, subject, type, subtype}, :infinity)
+  end
+
+  @impl Backend
+  def find_by_subjects(%Project{} = project, subjects, type, subtype) when is_list(subjects) do
+    GenServer.call(name(project), {:find_by_subjects, subjects, type, subtype}, :infinity)
+  end
+
+  @impl Backend
+  def find_by_caller(%Project{} = project, caller, path, type, subtype)
+      when is_binary(caller) and is_binary(path) do
+    GenServer.call(name(project), {:find_by_caller, caller, path, type, subtype}, :infinity)
   end
 
   @impl Backend
@@ -226,6 +237,12 @@ defmodule Expert.Search.Store.Backends.Sqlite do
 
   def handle_call({:find_by_subject, subject, type, subtype}, _from, %State{} = state),
     do: reply(do_find_by_subject(state, subject, type, subtype), state)
+
+  def handle_call({:find_by_subjects, subjects, type, subtype}, _from, %State{} = state),
+    do: reply(do_find_by_subjects(state, subjects, type, subtype), state)
+
+  def handle_call({:find_by_caller, caller, path, type, subtype}, _from, %State{} = state),
+    do: reply(do_find_by_caller(state, caller, path, type, subtype), state)
 
   def handle_call({:find_by_prefix, prefix, type, subtype}, _from, %State{} = state),
     do: reply(do_find_by_prefix(state, prefix, type, subtype), state)
@@ -376,6 +393,39 @@ defmodule Expert.Search.Store.Backends.Sqlite do
     |> entries_result()
   end
 
+  def do_find_by_subjects(%State{} = state, subjects, type, subtype) when is_list(subjects) do
+    result =
+      subjects
+      |> Enum.map(&subject_key/1)
+      |> Enum.uniq()
+      |> Stream.chunk_every(query_chunk_size(type, subtype))
+      |> Enum.reduce_while([], fn subjects, batches ->
+        {where, args} =
+          constraints(["subject IN (#{placeholders(subjects)})"], subjects, type, subtype)
+
+        state
+        |> query_entries(where_clause(where), args)
+        |> entries_result()
+        |> case do
+          entries when is_list(entries) -> {:cont, [entries | batches]}
+          {:error, _} = error -> {:halt, error}
+        end
+      end)
+
+    case result do
+      {:error, _} = error -> error
+      batches -> batches |> Enum.reverse() |> List.flatten()
+    end
+  end
+
+  def do_find_by_caller(%State{} = state, caller, path, type, subtype) do
+    {where, args} = constraints(["caller = ? AND path = ?"], [caller, path], type, subtype)
+
+    state
+    |> query_entries(where_clause(where), args)
+    |> entries_result()
+  end
+
   def do_find_by_prefix(%State{} = state, prefix, type, subtype) do
     {clauses, args} = prefix_constraint(prefix)
     {where, args} = constraints(clauses, args, type, subtype)
@@ -401,6 +451,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
                    entries.id,
                    entries.path,
                    entries.subject,
+                   entries.caller,
                    entries.type,
                    entries.subtype,
                    entries.block_id,
@@ -430,7 +481,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
     result =
       paths
       |> Enum.uniq()
-      |> Stream.chunk_every(path_chunk_size(type, subtype))
+      |> Stream.chunk_every(query_chunk_size(type, subtype))
       |> Enum.reduce_while([], fn paths, batches ->
         case find_by_path_chunk(state, paths, type, subtype) do
           entries when is_list(entries) -> {:cont, [entries | batches]}
@@ -460,6 +511,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
              entries.id,
              entries.path,
              entries.subject,
+             entries.caller,
              entries.type,
              entries.subtype,
              entries.block_id,
@@ -616,6 +668,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
       id INTEGER NOT NULL,
       path TEXT NOT NULL,
       subject TEXT NOT NULL,
+      caller TEXT,
       type BLOB NOT NULL,
       subtype TEXT NOT NULL,
       block_id INTEGER NOT NULL
@@ -646,6 +699,11 @@ defmodule Expert.Search.Store.Backends.Sqlite do
            exec(
              state,
              "CREATE INDEX IF NOT EXISTS entries_subject_idx ON entries (subject, type, subtype)"
+           ),
+         :ok <-
+           exec(
+             state,
+             "CREATE INDEX IF NOT EXISTS entries_caller_idx ON entries (caller, path, type, subtype)"
            ),
          :ok <-
            exec(state, "CREATE INDEX IF NOT EXISTS entries_block_idx ON entries (block_id, path)"),
@@ -711,8 +769,8 @@ defmodule Expert.Search.Store.Backends.Sqlite do
 
   defp insert_entry_rows(%State{} = state, rows) do
     sql = """
-    INSERT INTO entries (entry_key, id, path, subject, type, subtype, block_id)
-    VALUES #{row_placeholders(rows, 7)}
+    INSERT INTO entries (entry_key, id, path, subject, caller, type, subtype, block_id)
+    VALUES #{row_placeholders(rows, 8)}
     """
 
     args = Enum.flat_map(rows, &entry_args/1)
@@ -760,6 +818,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
       entry.id,
       entry.path,
       subject_key(entry.subject),
+      entry.caller,
       blob(entry.type),
       subtype_key(entry.subtype),
       block_id_key(entry.block_id)
@@ -827,6 +886,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
         entries.id,
         entries.path,
         entries.subject,
+        entries.caller,
         entries.type,
         entries.subtype,
         entries.block_id,
@@ -848,7 +908,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
     |> entries_result()
   end
 
-  defp path_chunk_size(type, subtype) do
+  defp query_chunk_size(type, subtype) do
     @sqlite_variable_limit - Enum.count([type, subtype], &(&1 != :_))
   end
 
@@ -1112,7 +1172,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
     blob({subject_override, entry.application, entry.block_range, entry.range, entry.metadata})
   end
 
-  defp decode_entry([id, path, subject_key, type_blob, subtype, block_id, entry_blob]) do
+  defp decode_entry([id, path, subject_key, caller, type_blob, subtype, block_id, entry_blob]) do
     {subject_override, application, block_range, range, metadata} = decode_term(entry_blob)
 
     subject =
@@ -1129,6 +1189,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
       path: path,
       range: range,
       subject: subject,
+      caller: caller,
       subtype: String.to_existing_atom(subtype),
       type: decode_term(type_blob),
       metadata: metadata

--- a/apps/expert/lib/expert/search/store/state.ex
+++ b/apps/expert/lib/expert/search/store/state.ex
@@ -95,6 +95,30 @@ defmodule Expert.Search.Store.State do
     end
   end
 
+  def exact_many(%__MODULE__{loaded?: false}, _subjects, _constraints), do: {:error, :loading}
+
+  def exact_many(%__MODULE__{} = state, subjects, constraints) do
+    type = Keyword.get(constraints, :type, :_)
+    subtype = Keyword.get(constraints, :subtype, :_)
+
+    case state.backend.find_by_subjects(state.project, subjects, type, subtype) do
+      l when is_list(l) -> {:ok, l}
+      error -> error
+    end
+  end
+
+  def by_caller(%__MODULE__{loaded?: false}, _caller, _path, _constraints), do: {:error, :loading}
+
+  def by_caller(%__MODULE__{} = state, caller, path, constraints) do
+    type = Keyword.get(constraints, :type, :_)
+    subtype = Keyword.get(constraints, :subtype, :_)
+
+    case state.backend.find_by_caller(state.project, caller, path, type, subtype) do
+      l when is_list(l) -> {:ok, l}
+      error -> error
+    end
+  end
+
   def prefix(%__MODULE__{loaded?: false}, _prefix, _constraints), do: {:error, :loading}
 
   def prefix(%__MODULE__{} = state, prefix, constraints) do

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -408,6 +408,7 @@ defmodule Expert.State do
 
     server_capabilities =
       %Structures.ServerCapabilities{
+        call_hierarchy_provider: true,
         code_action_provider: code_action_options,
         code_lens_provider: code_lens_options,
         completion_provider: completion_options,

--- a/apps/expert/test/expert/provider/handlers/call_hierarchy_test.exs
+++ b/apps/expert/test/expert/provider/handlers/call_hierarchy_test.exs
@@ -1,0 +1,918 @@
+defmodule Expert.Provider.Handlers.CallHierarchyTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  import Forge.Test.CursorSupport
+
+  alias Engine.CodeIntelligence.Entity
+  alias Engine.Search.Indexer.Source
+  alias Expert.Document.Context
+  alias Expert.EngineApi
+  alias Expert.Protocol.Convert
+  alias Expert.Provider.Handlers.CallHierarchy
+  alias Expert.Search.Store
+  alias Expert.Search.Store.Backends.Sqlite
+  alias Forge.Document
+  alias Forge.Project
+  alias GenLSP.Requests
+  alias GenLSP.Structures
+
+  setup do
+    {:ok, _} = Application.ensure_all_started(:briefly)
+    # Test-name directories can exceed Windows' path limit once SQLite appends its journal suffix.
+    {:ok, tmp_dir} = Briefly.create(directory: true)
+    project = tmp_dir |> Document.Path.to_uri() |> Project.new()
+    start_supervised!(Engine.ApplicationCache)
+    start_supervised!(Expert.Application.document_store_child_spec())
+
+    start_supervised!(
+      {Sqlite, [project, runtime_versions: %{erlang: "test-erlang", elixir: "test-elixir"}]}
+    )
+
+    start_supervised!({Store, [project, Sqlite]})
+    {:ok, supervisor} = ExUnit.fetch_test_supervisor()
+    # Delete the directory after the supervised SQLite connection has closed.
+    :ok = Briefly.give_away(tmp_dir, supervisor)
+    assert :ok = Store.enable(project)
+
+    patch(EngineApi, :resolve_entity, fn ^project, analysis, position ->
+      Entity.resolve(analysis, position)
+    end)
+
+    {:ok, project: project}
+  end
+
+  describe "prepare" do
+    test "returns no items for a module declaration", %{project: project} do
+      documents =
+        index(project, [
+          {"checkout.ex",
+           """
+           defmodule Chec|kout do
+             value = :ready
+           end
+           """}
+        ])
+
+      assert [] = prepare(documents["checkout.ex"], project)
+    end
+
+    test "returns no items for a non-call module expression", %{project: project} do
+      documents =
+        index(project, [
+          {"checkout.ex",
+           """
+           defmodule Checkout do
+             value = :ready
+             val|ue
+           end
+           """}
+        ])
+
+      assert [] = prepare(documents["checkout.ex"], project)
+    end
+
+    test "returns no items for a keyword-do module declaration", %{project: project} do
+      documents =
+        index(project, [
+          {"checkout.ex", "defmodule Chec|kout, do: :ok"}
+        ])
+
+      assert [] = prepare(documents["checkout.ex"], project)
+    end
+
+    test "returns no items for a protocol declaration", %{project: project} do
+      documents =
+        index(project, [
+          {"action.ex",
+           """
+           defprotocol Act|ion do
+             def run(value)
+           end
+           """}
+        ])
+
+      assert [] = prepare(documents["action.ex"], project)
+    end
+
+    test "returns no items for a non-call implementation expression", %{project: project} do
+      documents =
+        index(project, [
+          {"action.ex",
+           """
+           defimpl Action, for: Atom, do: (
+             value = :ready
+             val|ue
+           )
+           """}
+        ])
+
+      assert [] = prepare(documents["action.ex"], project)
+    end
+
+    test "returns no items for a non-call nested module expression", %{project: project} do
+      documents =
+        index(project, [
+          {"checkout.ex",
+           """
+           defmodule Checkout do
+             defmodule Nested do
+               value = :ready
+               val|ue
+             end
+           end
+           """}
+        ])
+
+      assert [] = prepare(documents["checkout.ex"], project)
+    end
+
+    test "returns no items for a top-level non-call expression", %{project: project} do
+      documents =
+        index(project, [
+          {"boot.exs",
+           """
+           value = :ready
+           val|ue
+           """}
+        ])
+
+      assert [] = prepare(documents["boot.exs"], project)
+    end
+
+    test "returns no items for an empty file", %{project: project} do
+      documents = index(project, [{"empty.exs", "|"}])
+
+      assert [] = prepare(documents["empty.exs"], project)
+    end
+
+    test "keeps non-call positions inside named functions empty", %{project: project} do
+      documents =
+        index(project, [
+          {"checkout.ex",
+           """
+           defmodule Checkout do
+             def submit(value), do: val|ue
+           end
+           """}
+        ])
+
+      assert [] = prepare(documents["checkout.ex"], project)
+    end
+
+    test "resolves function calls at module and file level", %{project: project} do
+      documents =
+        index(project, [
+          {"boot.exs", "Payments.cha|rge(:file)"},
+          {"startup.ex",
+           """
+           defmodule Startup do
+             Payments.cha|rge(:module)
+           end
+           """},
+          {"payments.ex",
+           """
+           defmodule Payments do
+             def charge(value), do: value
+           end
+           """}
+        ])
+
+      assert [file_call] = prepare(documents["boot.exs"], project)
+      assert [module_call] = prepare(documents["startup.ex"], project)
+      assert file_call.name == "Payments.charge/1"
+      assert file_call.kind == GenLSP.Enumerations.SymbolKind.function()
+      assert module_call == file_call
+    end
+
+    test "resolves an aliased remote call to its definition", %{project: project} do
+      documents =
+        index(project, [
+          {"checkout.ex",
+           """
+           defmodule Checkout do
+             alias Billing.Payments, as: Payments
+             def submit(cart), do: Payments.cha|rge(cart)
+           end
+           """},
+          {"payments.ex",
+           """
+           defmodule Billing.Payments do
+             def charge(cart) do
+               {:ok, cart}
+             end
+           end
+           """}
+        ])
+
+      {payments, _position} = documents["payments.ex"]
+      assert [%Structures.CallHierarchyItem{} = item] = prepare(documents["checkout.ex"], project)
+
+      assert item.name == "Billing.Payments.charge/1"
+      assert item.kind == GenLSP.Enumerations.SymbolKind.function()
+      assert item.uri == payments.uri
+      assert text_at(payments, item.selection_range) == "charge(cart)"
+      assert item.range == lsp_range(1, 2, 3, 5)
+      assert item.data == %{"project_root_uri" => project.root_uri}
+    end
+
+    test "resolves a local call to its definition", %{project: project} do
+      documents =
+        index(project, [
+          {"checkout.ex",
+           """
+           defmodule Checkout do
+             def submit(cart), do: vali|date(cart)
+             defp validate(cart) do
+               cart
+             end
+           end
+           """}
+        ])
+
+      {checkout, _position} = documents["checkout.ex"]
+      assert [%Structures.CallHierarchyItem{} = item] = prepare(documents["checkout.ex"], project)
+
+      assert item.name == "Checkout.validate/1"
+      assert item.kind == GenLSP.Enumerations.SymbolKind.function()
+      assert item.uri == checkout.uri
+      assert text_at(checkout, item.selection_range) == "validate(cart)"
+      assert item.range == lsp_range(2, 2, 4, 5)
+      assert item.data == %{"project_root_uri" => project.root_uri}
+    end
+
+    test "resolves the called arity", %{project: project} do
+      documents =
+        index(project, [
+          {"parser.ex",
+           """
+           defmodule Parser do
+             def run(input), do: par|se(input, :strict)
+             def parse(input), do: input
+             def parse(input, mode), do: {input, mode}
+           end
+           """}
+        ])
+
+      {parser, _position} = documents["parser.ex"]
+      assert [%Structures.CallHierarchyItem{} = item] = prepare(documents["parser.ex"], project)
+
+      assert item.name == "Parser.parse/2"
+      assert item.kind == GenLSP.Enumerations.SymbolKind.function()
+      assert item.uri == parser.uri
+      assert text_at(parser, item.selection_range) == "parse(input, mode)"
+      assert text_at(parser, item.range) == "def parse(input, mode), do: {input, mode}"
+      assert item.data == %{"project_root_uri" => project.root_uri}
+    end
+
+    test "accounts for the argument supplied by a pipe", %{project: project} do
+      documents =
+        index(project, [
+          {"renderer.ex",
+           """
+           defmodule Renderer do
+             def render(text), do: text |> normal|ize()
+             defp normalize(text), do: text
+           end
+           """}
+        ])
+
+      {renderer, _position} = documents["renderer.ex"]
+      assert [%Structures.CallHierarchyItem{} = item] = prepare(documents["renderer.ex"], project)
+
+      assert item.name == "Renderer.normalize/1"
+      assert item.kind == GenLSP.Enumerations.SymbolKind.function()
+      assert item.uri == renderer.uri
+      assert text_at(renderer, item.selection_range) == "normalize(text)"
+      assert text_at(renderer, item.range) == "defp normalize(text), do: text"
+      assert item.data == %{"project_root_uri" => project.root_uri}
+    end
+  end
+
+  describe "incoming" do
+    test "returns caller definitions and call sites from each caller's file", %{project: project} do
+      documents =
+        index(project, [
+          {"payments.ex",
+           """
+           defmodule Payments do
+             def cha|rge(cart), do: {:ok, cart}
+           end
+           """},
+          {"checkout.ex",
+           """
+           defmodule Checkout do
+             def submit(cart), do: Payments.charge(cart)
+           end
+           """},
+          {"retry_job.ex",
+           """
+           defmodule RetryJob do
+             def perform(cart), do: Payments.charge(cart)
+           end
+           """}
+        ])
+
+      {checkout_document, _position} = documents["checkout.ex"]
+      {retry_document, _position} = documents["retry_job.ex"]
+      assert [charge] = prepare(documents["payments.ex"], project)
+      assert [checkout, retry] = charge |> incoming(project) |> Enum.sort_by(& &1.from.name)
+
+      assert checkout.from.name == "Checkout.submit/1"
+      assert checkout.from.uri == checkout_document.uri
+      assert text_at(checkout_document, checkout.from.selection_range) == "submit(cart)"
+
+      assert text_at(checkout_document, checkout.from.range) ==
+               "def submit(cart), do: Payments.charge(cart)"
+
+      assert Enum.map(checkout.from_ranges, &text_at(checkout_document, &1)) ==
+               ["Payments.charge(cart)"]
+
+      assert retry.from.name == "RetryJob.perform/1"
+      assert retry.from.uri == retry_document.uri
+      assert text_at(retry_document, retry.from.selection_range) == "perform(cart)"
+
+      assert text_at(retry_document, retry.from.range) ==
+               "def perform(cart), do: Payments.charge(cart)"
+
+      assert Enum.map(retry.from_ranges, &text_at(retry_document, &1)) ==
+               ["Payments.charge(cart)"]
+    end
+
+    test "groups repeated calls from the same function into one caller item", %{project: project} do
+      documents =
+        index(project, [
+          {"payments.ex",
+           """
+           defmodule Payments do
+             def cha|rge(amount), do: amount
+
+             def pay do
+               charge(:deposit)
+               charge(:balance)
+             end
+           end
+           """}
+        ])
+
+      {document, _position} = documents["payments.ex"]
+      assert [charge] = prepare(documents["payments.ex"], project)
+      assert [payment] = incoming(charge, project)
+
+      assert payment.from.name == "Payments.pay/0"
+
+      call_sites =
+        payment.from_ranges
+        |> Enum.sort_by(&{&1.start.line, &1.start.character})
+        |> Enum.map(&text_at(document, &1))
+
+      assert call_sites == ["charge(:deposit)", "charge(:balance)"]
+    end
+
+    test "does not include callers of a different arity", %{project: project} do
+      documents =
+        index(project, [
+          {"parser.ex",
+           """
+           defmodule Parser do
+             def par|se(input), do: input
+             def parse(input, mode), do: {input, mode}
+             def normal(input), do: parse(input)
+             def strict(input), do: parse(input, :strict)
+           end
+           """}
+        ])
+
+      {document, _position} = documents["parser.ex"]
+      assert [parse] = prepare(documents["parser.ex"], project)
+      assert [normal] = incoming(parse, project)
+
+      assert normal.from.name == "Parser.normal/1"
+      assert Enum.map(normal.from_ranges, &text_at(document, &1)) == ["parse(input)"]
+    end
+
+    test "returns direct callers and expands the next level only when requested", %{
+      project: project
+    } do
+      documents =
+        index(project, [
+          {"workflow.ex",
+           """
+           defmodule Workflow do
+             def start(), do: middle()
+             defp middle(), do: finish()
+             defp fin|ish(), do: :ok
+           end
+           """}
+        ])
+
+      {document, _position} = documents["workflow.ex"]
+      assert [finish] = prepare(documents["workflow.ex"], project)
+      assert [middle] = incoming(finish, project)
+      assert middle.from.name == "Workflow.middle/0"
+      assert Enum.map(middle.from_ranges, &text_at(document, &1)) == ["finish()"]
+
+      assert [start] = incoming(middle.from, project)
+      assert start.from.name == "Workflow.start/0"
+      assert Enum.map(start.from_ranges, &text_at(document, &1)) == ["middle()"]
+    end
+
+    test "returns no callers for an unreferenced function", %{project: project} do
+      documents =
+        index(project, [
+          {"payments.ex",
+           """
+           defmodule Payments do
+             def cha|rge(cart), do: cart
+           end
+           """}
+        ])
+
+      assert [charge] = prepare(documents["payments.ex"], project)
+      assert [] = incoming(charge, project)
+    end
+
+    test "includes module-body calls separately from function calls", %{project: project} do
+      documents =
+        index(project, [
+          {"payments.ex",
+           """
+           defmodule Payments do
+             def cha|rge(cart), do: cart
+           end
+           """},
+          {"checkout.ex",
+           """
+           defmodule Checkout do
+             def submit(cart), do: Payments.charge(cart)
+             Payments.charge(:module_level)
+           end
+           """}
+        ])
+
+      {document, _position} = documents["checkout.ex"]
+      assert [charge] = prepare(documents["payments.ex"], project)
+      assert [module, checkout] = charge |> incoming(project) |> Enum.sort_by(& &1.from.name)
+
+      assert checkout.from.name == "Checkout.submit/1"
+      assert Enum.map(checkout.from_ranges, &text_at(document, &1)) == ["Payments.charge(cart)"]
+      assert module.from.name == "Checkout"
+      assert module.from.kind == GenLSP.Enumerations.SymbolKind.module()
+
+      assert Enum.map(module.from_ranges, &text_at(document, &1)) == [
+               "Payments.charge(:module_level)"
+             ]
+    end
+
+    test "includes file and module callers as terminal locations alongside function callers", %{
+      project: project
+    } do
+      documents =
+        index(project, [
+          {"boot.exs",
+           """
+           Payments.charge(:script)
+
+           defmodule Checkout do
+             Payments.charge(:module)
+
+             def submit(cart), do: Payments.charge(cart)
+           end
+           """},
+          {"payments.ex",
+           """
+           defmodule Payments do
+             def cha|rge(value), do: value
+           end
+           """}
+        ])
+
+      {document, _position} = documents["boot.exs"]
+      assert [charge] = prepare(documents["payments.ex"], project)
+
+      assert [file, module, function] =
+               charge |> incoming(project) |> Enum.sort_by(& &1.from.kind)
+
+      assert file.from.kind == GenLSP.Enumerations.SymbolKind.file()
+      assert file.from.name == "boot.exs"
+      assert file.from.uri == document.uri
+      assert file.from.range == lsp_range(0, 0, 7, 0)
+      assert file.from.selection_range == lsp_range(0, 0, 0, 0)
+      assert file.from.data == %{"project_root_uri" => project.root_uri}
+      assert Enum.map(file.from_ranges, &text_at(document, &1)) == ["Payments.charge(:script)"]
+
+      assert module.from.kind == GenLSP.Enumerations.SymbolKind.module()
+      assert module.from.name == "Checkout"
+      assert module.from.uri == document.uri
+      assert module.from.range == lsp_range(2, 0, 6, 3)
+      assert module.from.data == %{"project_root_uri" => project.root_uri}
+      assert text_at(document, module.from.selection_range) == "Checkout"
+      assert Enum.map(module.from_ranges, &text_at(document, &1)) == ["Payments.charge(:module)"]
+
+      assert function.from.name == "Checkout.submit/1"
+      assert Enum.map(function.from_ranges, &text_at(document, &1)) == ["Payments.charge(cart)"]
+
+      assert [] = outgoing(file.from, project)
+      assert [] = outgoing(module.from, project)
+
+      assert [function_call] = outgoing(function.from, project)
+      assert function_call.to == charge
+      assert function_call.from_ranges == function.from_ranges
+
+      assert [] = incoming(file.from, project)
+      assert [] = incoming(module.from, project)
+    end
+
+    test "loads an unopened script to construct its file caller item", %{project: project} do
+      documents =
+        index(project, [
+          {"boot.exs", "Payments.charge(:script)\n"},
+          {"payments.ex",
+           """
+           defmodule Payments do
+             def cha|rge(value), do: value
+           end
+           """}
+        ])
+
+      {script, _position} = documents["boot.exs"]
+      File.write!(script.path, Document.to_string(script))
+      assert :ok = Document.Store.close(script.uri)
+      assert [charge] = prepare(documents["payments.ex"], project)
+      assert [caller] = incoming(charge, project)
+      assert caller.from.kind == GenLSP.Enumerations.SymbolKind.file()
+      assert caller.from.uri == script.uri
+      assert caller.from.range == lsp_range(0, 0, 1, 0)
+    end
+
+    test "uses a UTF-16 file caller extent when the last line has no newline", %{project: project} do
+      documents =
+        index(project, [
+          {"boot.exs", "Payments.charge(:script)\n# \u{1F680}"},
+          {"payments.ex",
+           """
+           defmodule Payments do
+             def cha|rge(value), do: value
+           end
+           """}
+        ])
+
+      {script, _position} = documents["boot.exs"]
+      assert [charge] = prepare(documents["payments.ex"], project)
+      assert [caller] = incoming(charge, project)
+      assert caller.from.kind == GenLSP.Enumerations.SymbolKind.file()
+      assert caller.from.uri == script.uri
+      assert caller.from.range == lsp_range(0, 0, 1, 4)
+      assert Enum.map(caller.from_ranges, &text_at(script, &1)) == ["Payments.charge(:script)"]
+    end
+
+    test "includes the function itself as a caller when it recurses", %{project: project} do
+      documents =
+        index(project, [
+          {"counter.ex",
+           """
+           defmodule Counter do
+             def count|down(value) do
+               if value > 0 do
+                 countdown(value - 1)
+               end
+             end
+           end
+           """}
+        ])
+
+      {document, _position} = documents["counter.ex"]
+      assert [countdown] = prepare(documents["counter.ex"], project)
+      assert [recursive_call] = incoming(countdown, project)
+
+      assert recursive_call.from == countdown
+
+      assert Enum.map(recursive_call.from_ranges, &text_at(document, &1)) ==
+               ["countdown(value - 1)"]
+    end
+  end
+
+  describe "outgoing" do
+    test "uses the prepared definition's document when invoked at a call in another file", %{
+      project: project
+    } do
+      documents =
+        index(project, [
+          {"checkout.ex",
+           """
+           defmodule Checkout do
+             def submit(order), do: Payments.cha|rge(order)
+           end
+           """},
+          {"payments.ex",
+           """
+           defmodule Payments do
+             def charge(order) do
+               Processor.process(order)
+             end
+           end
+           """},
+          {"processor.ex",
+           """
+           defmodule Processor do
+             def process(order), do: {:ok, order}
+           end
+           """}
+        ])
+
+      {payments, _position} = documents["payments.ex"]
+      {processor, _position} = documents["processor.ex"]
+      assert [charge] = prepare(documents["checkout.ex"], project)
+      assert charge.name == "Payments.charge/1"
+      assert charge.uri == payments.uri
+
+      request = %Requests.CallHierarchyOutgoingCalls{
+        id: 3,
+        params: %Structures.CallHierarchyOutgoingCallsParams{item: charge}
+      }
+
+      assert {:ok, %Context{document: document, project: ^project}} =
+               Expert.Document.Lookup.resolve_from_request(request, [project])
+
+      assert document.uri == payments.uri
+      assert [call] = handle(request, project, document)
+      assert call.to.name == "Processor.process/1"
+      assert call.to.uri == processor.uri
+      assert text_at(processor, call.to.selection_range) == "process(order)"
+      assert call.from_ranges == [lsp_range(2, 4, 2, 28)]
+      assert Enum.map(call.from_ranges, &text_at(payments, &1)) == ["Processor.process(order)"]
+    end
+
+    test "returns callees, not callers or calls inside unrelated functions", %{project: project} do
+      documents =
+        index(project, [
+          {"checkout.ex",
+           """
+           defmodule Checkout do
+             def start(cart), do: submit(cart)
+
+             def sub|mit(cart) do
+               validate(cart)
+               persist(cart)
+             end
+
+             defp validate(cart), do: cart
+             defp persist(cart), do: {:ok, cart}
+             def unrelated(cart), do: audit(cart)
+             defp audit(cart), do: cart
+           end
+           """}
+        ])
+
+      {document, _position} = documents["checkout.ex"]
+      assert [submit] = prepare(documents["checkout.ex"], project)
+      assert [persist, validate] = submit |> outgoing(project) |> Enum.sort_by(& &1.to.name)
+
+      assert persist.to.name == "Checkout.persist/1"
+      assert persist.to.uri == document.uri
+      assert text_at(document, persist.to.selection_range) == "persist(cart)"
+      assert text_at(document, persist.to.range) == "defp persist(cart), do: {:ok, cart}"
+      assert Enum.map(persist.from_ranges, &text_at(document, &1)) == ["persist(cart)"]
+
+      assert validate.to.name == "Checkout.validate/1"
+      assert validate.to.uri == document.uri
+      assert text_at(document, validate.to.selection_range) == "validate(cart)"
+      assert text_at(document, validate.to.range) == "defp validate(cart), do: cart"
+      assert Enum.map(validate.from_ranges, &text_at(document, &1)) == ["validate(cart)"]
+    end
+
+    test "uses the callee's file for its definition and the caller's file for call sites", %{
+      project: project
+    } do
+      documents =
+        index(project, [
+          {"checkout.ex",
+           """
+           defmodule Checkout do
+             def sub|mit(order) do
+               Payments.charge(order)
+             end
+           end
+           """},
+          {"payments.ex",
+           """
+           defmodule Payments do
+             def charge(cart) do
+               {:ok, cart}
+             end
+           end
+           """}
+        ])
+
+      {checkout_document, _position} = documents["checkout.ex"]
+      {payments_document, _position} = documents["payments.ex"]
+      assert [submit] = prepare(documents["checkout.ex"], project)
+      assert [charge] = outgoing(submit, project)
+
+      assert charge.to.name == "Payments.charge/1"
+      assert charge.to.uri == payments_document.uri
+      assert text_at(payments_document, charge.to.selection_range) == "charge(cart)"
+      assert charge.to.range == lsp_range(1, 2, 3, 5)
+
+      assert Enum.map(charge.from_ranges, &text_at(checkout_document, &1)) ==
+               ["Payments.charge(order)"]
+    end
+
+    test "groups repeated calls to one function into one callee item", %{project: project} do
+      documents =
+        index(project, [
+          {"workflow.ex",
+           """
+           defmodule Workflow do
+             def ru|n do
+               record(:started)
+               record(:finished)
+             end
+
+             defp record(event), do: event
+           end
+           """}
+        ])
+
+      {document, _position} = documents["workflow.ex"]
+      assert [run] = prepare(documents["workflow.ex"], project)
+      assert [record] = outgoing(run, project)
+
+      assert record.to.name == "Workflow.record/1"
+
+      call_sites =
+        record.from_ranges
+        |> Enum.sort_by(&{&1.start.line, &1.start.character})
+        |> Enum.map(&text_at(document, &1))
+
+      assert call_sites == ["record(:started)", "record(:finished)"]
+    end
+
+    test "keeps calls to different arities as separate callees", %{project: project} do
+      documents =
+        index(project, [
+          {"parser.ex",
+           """
+           defmodule Parser do
+             def ru|n(input) do
+               parse(input)
+               parse(input, :strict)
+             end
+
+             def parse(input), do: input
+             def parse(input, mode), do: {input, mode}
+           end
+           """}
+        ])
+
+      {document, _position} = documents["parser.ex"]
+      assert [run] = prepare(documents["parser.ex"], project)
+      assert [normal, strict] = run |> outgoing(project) |> Enum.sort_by(& &1.to.name)
+
+      assert normal.to.name == "Parser.parse/1"
+      assert text_at(document, normal.to.selection_range) == "parse(input)"
+      assert Enum.map(normal.from_ranges, &text_at(document, &1)) == ["parse(input)"]
+
+      assert strict.to.name == "Parser.parse/2"
+      assert text_at(document, strict.to.selection_range) == "parse(input, mode)"
+      assert Enum.map(strict.from_ranges, &text_at(document, &1)) == ["parse(input, :strict)"]
+    end
+
+    test "returns direct callees and expands the next level only when requested", %{
+      project: project
+    } do
+      documents =
+        index(project, [
+          {"workflow.ex",
+           """
+           defmodule Workflow do
+             def sta|rt(), do: middle()
+             defp middle(), do: finish()
+             defp finish(), do: :ok
+           end
+           """}
+        ])
+
+      {document, _position} = documents["workflow.ex"]
+      assert [start] = prepare(documents["workflow.ex"], project)
+      assert [middle] = outgoing(start, project)
+      assert middle.to.name == "Workflow.middle/0"
+      assert Enum.map(middle.from_ranges, &text_at(document, &1)) == ["middle()"]
+
+      assert [finish] = outgoing(middle.to, project)
+      assert finish.to.name == "Workflow.finish/0"
+      assert Enum.map(finish.from_ranges, &text_at(document, &1)) == ["finish()"]
+    end
+
+    test "returns no callees for a function whose body makes no calls", %{project: project} do
+      documents =
+        index(project, [
+          {"identity.ex",
+           """
+           defmodule Identity do
+             def ke|ep(value), do: value
+           end
+           """}
+        ])
+
+      assert [keep] = prepare(documents["identity.ex"], project)
+      assert [] = outgoing(keep, project)
+    end
+
+    test "includes the function itself as a callee when it recurses", %{project: project} do
+      documents =
+        index(project, [
+          {"counter.ex",
+           """
+           defmodule Counter do
+             def count|down(value) do
+               if value > 0 do
+                 countdown(value - 1)
+               end
+             end
+           end
+           """}
+        ])
+
+      {document, _position} = documents["counter.ex"]
+      assert [countdown] = prepare(documents["counter.ex"], project)
+      assert [recursive_call] = outgoing(countdown, project)
+
+      assert recursive_call.to == countdown
+
+      assert Enum.map(recursive_call.from_ranges, &text_at(document, &1)) ==
+               ["countdown(value - 1)"]
+    end
+  end
+
+  defp index(project, sources) do
+    indexed =
+      for {name, source} <- sources do
+        uri = project |> Project.root_path() |> Path.join(name) |> Document.Path.to_uri()
+        {position, document} = pop_cursor(source, document: uri)
+        assert :ok = Document.Store.open(uri, Document.to_string(document), 0)
+        assert {:ok, entries} = Source.index(document.path, Document.to_string(document))
+        {name, document, position, entries}
+      end
+
+    entries = Enum.flat_map(indexed, fn {_name, _document, _position, entries} -> entries end)
+    assert :ok = Store.replace(project, entries)
+
+    Map.new(indexed, fn {name, document, position, _entries} -> {name, {document, position}} end)
+  end
+
+  defp prepare({document, position}, project) do
+    assert {:ok, position} = Convert.to_lsp(position)
+
+    request = %Requests.TextDocumentPrepareCallHierarchy{
+      id: 1,
+      params: %Structures.CallHierarchyPrepareParams{
+        text_document: %Structures.TextDocumentIdentifier{uri: document.uri},
+        position: position
+      }
+    }
+
+    handle(request, project, document)
+  end
+
+  defp incoming(item, project) do
+    request = %Requests.CallHierarchyIncomingCalls{
+      id: 2,
+      params: %Structures.CallHierarchyIncomingCallsParams{item: item}
+    }
+
+    assert {:ok, document} = Document.Store.fetch(item.uri)
+    handle(request, project, document)
+  end
+
+  defp outgoing(item, project) do
+    request = %Requests.CallHierarchyOutgoingCalls{
+      id: 3,
+      params: %Structures.CallHierarchyOutgoingCallsParams{item: item}
+    }
+
+    assert {:ok, document} = Document.Store.fetch(item.uri)
+    handle(request, project, document)
+  end
+
+  defp handle(request, project, document) do
+    context = Context.new(document.uri, document, project)
+    assert {:ok, native_request} = Convert.to_native(request, document)
+    assert {:ok, result} = CallHierarchy.handle(native_request, context)
+    assert {:ok, result} = Convert.to_lsp(result)
+    assert {:ok, _json} = Schematic.dump(request.__struct__.result(), result)
+    result
+  end
+
+  defp text_at(document, range) do
+    assert {:ok, range} = Expert.Protocol.Conversions.to_elixir(range, document)
+    Document.fragment(document, range.start, range.end)
+  end
+
+  defp lsp_range(start_line, start_character, end_line, end_character) do
+    %Structures.Range{
+      start: %Structures.Position{line: start_line, character: start_character},
+      end: %Structures.Position{line: end_line, character: end_character}
+    }
+  end
+end

--- a/apps/expert/test/expert/search/store/backends/sqlite_test.exs
+++ b/apps/expert/test/expert/search/store/backends/sqlite_test.exs
@@ -99,6 +99,35 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
              end)
     end
 
+    test "stores entry caller", %{project: project, runtime_versions: runtime_versions} do
+      entry = %Entry{
+        id: 1,
+        block_id: :root,
+        path: "/orders.ex",
+        subject: "Payments.charge/1",
+        caller: "Orders.checkout/1",
+        type: {:function, :usage},
+        subtype: :reference
+      }
+
+      pid =
+        start_supervised!(%{
+          id: :sqlite,
+          start: {Sqlite, :start_link, [project, [runtime_versions: runtime_versions]]}
+        })
+
+      assert {:ok, :empty} = Sqlite.prepare(pid)
+      assert :ok = Sqlite.replace_all(project, [entry])
+
+      assert [^entry] =
+               Sqlite.find_by_subject(
+                 project,
+                 "Payments.charge/1",
+                 {:function, :usage},
+                 :reference
+               )
+    end
+
     test "stores lean entry blobs and reconstructs entries from both tables", %{
       project: project,
       runtime_versions: runtime_versions
@@ -173,7 +202,7 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
 
       {:ok, conn} = Exqlite.Basic.open(database_path)
       result = Exqlite.Basic.exec(conn, "SELECT version FROM schema")
-      assert {:ok, [[4]], ["version"]} = Exqlite.Basic.rows(result)
+      assert {:ok, [[5]], ["version"]} = Exqlite.Basic.rows(result)
       assert :ok = Exqlite.Basic.close(conn)
     end
   end
@@ -412,6 +441,176 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
       assert :ok = Sqlite.replace_all(project, [structure])
 
       assert {:ok, %{1 => %{2 => %{}}}} = Sqlite.structure_for_path(project, path)
+    end
+  end
+
+  describe "find_by_caller/5" do
+    test "adds the caller index to an existing database without losing entries", %{
+      project: project,
+      runtime_versions: runtime_versions
+    } do
+      entry = %Entry{
+        id: 1,
+        subject: "Payments.charge/1",
+        caller: "Orders.odd'_%/1",
+        path: "/orders'_%/file.ex",
+        type: {:function, :usage},
+        subtype: :reference,
+        block_id: :root
+      }
+
+      pid =
+        start_supervised!(%{
+          id: :sqlite,
+          start: {Sqlite, :start_link, [project, [runtime_versions: runtime_versions]]}
+        })
+
+      assert {:ok, :empty} = Sqlite.prepare(pid)
+      assert :ok = Sqlite.replace_all(project, [entry])
+      assert :ok = stop_supervised!(:sqlite)
+
+      {:ok, conn} = Exqlite.Basic.open(Sqlite.database_path(project, runtime_versions))
+
+      try do
+        # Simulate a persisted database created before the caller index was added.
+        result = Exqlite.Basic.exec(conn, "DROP INDEX entries_caller_idx")
+        assert {:ok, [], _columns} = Exqlite.Basic.rows(result)
+      after
+        Exqlite.Basic.close(conn)
+      end
+
+      pid =
+        start_supervised!(%{
+          id: :sqlite,
+          start: {Sqlite, :start_link, [project, [runtime_versions: runtime_versions]]}
+        })
+
+      assert {:ok, :stale} = Sqlite.prepare(pid)
+
+      assert [^entry] =
+               Sqlite.find_by_caller(project, entry.caller, entry.path, :_, :reference)
+
+      assert [] = Sqlite.find_by_caller(project, "Orders.oddX_%/1", entry.path, :_, :reference)
+
+      {:ok, conn} = Exqlite.Basic.open(Sqlite.database_path(project, runtime_versions))
+
+      try do
+        result =
+          Exqlite.Basic.exec(conn, "SELECT name FROM sqlite_master WHERE name = ?", [
+            "entries_caller_idx"
+          ])
+
+        assert {:ok, [["entries_caller_idx"]], _columns} = Exqlite.Basic.rows(result)
+      after
+        Exqlite.Basic.close(conn)
+      end
+    end
+  end
+
+  describe "find_by_subjects/4" do
+    setup %{project: project, runtime_versions: runtime_versions} do
+      pid =
+        start_supervised!(%{
+          id: :sqlite,
+          start: {Sqlite, :start_link, [project, [runtime_versions: runtime_versions]]}
+        })
+
+      assert {:ok, :empty} = Sqlite.prepare(pid)
+      :ok
+    end
+
+    test "matches exact subjects without collapsing clauses or duplicating entries", %{
+      project: project
+    } do
+      first = %Entry{
+        id: 1,
+        subject: "Orders.checkout/1",
+        path: "/orders.ex",
+        type: {:function, :public},
+        subtype: :definition,
+        block_id: :root
+      }
+
+      second = %{first | id: 2}
+      other = %{first | id: 3, subject: "Jobs.retry/1", path: "/jobs.ex"}
+      other_path = %{first | id: 4, path: "/other/orders.ex"}
+
+      reference = %{
+        first
+        | id: 5,
+          subtype: :reference,
+          type: {:function, :usage},
+          caller: "Jobs.retry/1"
+      }
+
+      macro = %{first | id: 6, type: {:macro, :public}}
+      other_arity = %{first | id: 7, subject: "Orders.checkout/2"}
+      literal = %{first | id: 8, subject: "odd'_%/0"}
+      module = %{first | id: 9, subject: Orders, type: :module}
+
+      assert :ok =
+               Sqlite.replace_all(project, [
+                 first,
+                 second,
+                 other,
+                 other_path,
+                 reference,
+                 macro,
+                 other_arity,
+                 literal,
+                 module
+               ])
+
+      subjects = ["Jobs.retry/1", "Orders.checkout/1", "Orders.checkout/1", "Missing.function/0"]
+
+      assert [^first, ^second, ^other, ^other_path] =
+               project
+               |> Sqlite.find_by_subjects(subjects, {:function, :public}, :definition)
+               |> Enum.sort_by(& &1.id)
+
+      assert [^first, ^second, ^other, ^other_path, ^reference, ^macro] =
+               project
+               |> Sqlite.find_by_subjects(subjects, :_, :_)
+               |> Enum.sort_by(& &1.id)
+
+      assert [^reference] = Sqlite.find_by_subjects(project, subjects, :_, :reference)
+      assert [^literal] = Sqlite.find_by_subjects(project, ["odd'_%/0"], :_, :_)
+      assert [^module] = Sqlite.find_by_subjects(project, [Orders, "Orders"], :_, :_)
+      assert [] = Sqlite.find_by_subjects(project, ["Orders.checkout"], :_, :_)
+      assert [] = Sqlite.find_by_subjects(project, [], :_, :_)
+    end
+
+    test "batches subjects within the parameter limit and retains matches from every batch", %{
+      project: project
+    } do
+      subjects = Enum.map(1..32_767, &"Generated.function_#{&1}/0")
+
+      entries =
+        for id <- [1, 32_765, 32_767] do
+          %Entry{
+            id: id,
+            subject: "Generated.function_#{id}/0",
+            path: "/generated.ex",
+            type: {:function, :public},
+            subtype: :definition,
+            block_id: :root
+          }
+        end
+
+      assert :ok = Sqlite.replace_all(project, entries)
+      subjects = subjects ++ ["Generated.function_1/0"]
+
+      for {type, subtype} <- [
+            {:_, :_},
+            {{:function, :public}, :_},
+            {:_, :definition},
+            {{:function, :public}, :definition}
+          ] do
+        assert ^entries =
+                 project
+                 |> Sqlite.find_by_subjects(subjects, type, subtype)
+                 |> Enum.sort_by(& &1.id)
+      end
     end
   end
 

--- a/apps/expert/test/expert/search/store/state_test.exs
+++ b/apps/expert/test/expert/search/store/state_test.exs
@@ -22,6 +22,21 @@ defmodule Expert.Search.Store.StateTest do
 
     def find_by_subject(_project, :_, :module, :definition), do: [entry(1)]
     def find_by_subject(_project, _subject, _type, _subtype), do: []
+    def find_by_subjects(_project, ["QueryBackend.Result"], :module, :definition), do: [entry(4)]
+    def find_by_subjects(_project, ["error"], :_, :_), do: {:error, :busy}
+    def find_by_subjects(_project, _subjects, _type, _subtype), do: []
+
+    def find_by_caller(
+          _project,
+          "QueryBackend.Result",
+          "/query_backend.ex",
+          :module,
+          :definition
+        ),
+        do: [entry(5)]
+
+    def find_by_caller(_project, "error", _path, :_, :_), do: {:error, :busy}
+    def find_by_caller(_project, _caller, _path, _type, _subtype), do: []
     def find_by_prefix(_project, _prefix, _type, _subtype), do: []
     def find_by_ids(_project, [2], :module, :definition), do: [entry(2)]
     def find_by_ids(_project, _ids, _type, _subtype), do: []
@@ -60,6 +75,8 @@ defmodule Expert.Search.Store.StateTest do
       do: {:ok, []}
 
     def find_by_subject(_project, _subject, _type, _subtype), do: []
+    def find_by_subjects(_project, _subjects, _type, _subtype), do: []
+    def find_by_caller(_project, _caller, _path, _type, _subtype), do: []
     def find_by_prefix(_project, _prefix, _type, _subtype), do: []
     def find_by_ids(_project, _ids, _type, _subtype), do: []
     def find_by_paths(_project, _paths, _type, _subtype), do: []
@@ -80,6 +97,36 @@ defmodule Expert.Search.Store.StateTest do
 
     assert {{:error, :not_started}, log} = with_log(fn -> State.load(state) end)
     assert log =~ "Could not initialize index backend"
+  end
+
+  test "exact_many forwards filters, wraps entries, and preserves backend errors" do
+    state = State.new(project(), QueryBackend)
+
+    assert {:error, :loading} = State.exact_many(state, ["QueryBackend.Result"], [])
+
+    state = %{state | loaded?: true}
+
+    assert {:ok, [%Entry{id: 4}]} =
+             State.exact_many(state, ["QueryBackend.Result"], type: :module, subtype: :definition)
+
+    assert {:ok, []} = State.exact_many(state, [], [])
+    assert {:error, :busy} = State.exact_many(state, ["error"], [])
+  end
+
+  test "by_caller forwards caller, path, and filters and preserves errors" do
+    state = State.new(project(), QueryBackend)
+    caller = "QueryBackend.Result"
+    path = "/query_backend.ex"
+
+    assert {:error, :loading} = State.by_caller(state, caller, path, [])
+
+    state = %{state | loaded?: true}
+
+    assert {:ok, [%Entry{id: 5}]} =
+             State.by_caller(state, caller, path, type: :module, subtype: :definition)
+
+    assert {:ok, []} = State.by_caller(state, caller, "/other.ex", [])
+    assert {:error, :busy} = State.by_caller(state, "error", path, [])
   end
 
   test "all reduces backend entries and fuzzy uses in-memory ids" do

--- a/apps/expert/test/expert/search/store_test.exs
+++ b/apps/expert/test/expert/search/store_test.exs
@@ -43,6 +43,134 @@ defmodule Expert.Search.StoreTest do
     assert entry.id == 1
   end
 
+  test "exact_many uses one indexed query and skips SQL for empty input", %{project: project} do
+    one = definition(id: 1, subject: Foo.Bar)
+    two = definition(id: 2, subject: Other.Module)
+
+    entries = [
+      one,
+      two,
+      reference(id: 3, subject: Foo.Bar),
+      definition(id: 4, subject: Unrelated)
+    ]
+
+    assert :ok = Store.replace(project, entries)
+    spy(Exqlite.Basic)
+
+    assert {:ok, []} = Store.exact_many(project, [], [])
+    refute_called(Exqlite.Basic.exec(_, _, _))
+
+    assert {:ok, matches} =
+             Store.exact_many(project, ["Foo.Bar", "Other.Module", "Foo.Bar"],
+               type: :module,
+               subtype: :definition
+             )
+
+    assert [^one, ^two] = Enum.sort_by(matches, & &1.id)
+    assert_called(Exqlite.Basic.exec(_, sql, args), 1)
+
+    {:ok, conn} = Exqlite.Basic.open(Sqlite.database_path(project, runtime_versions()))
+
+    try do
+      result = Exqlite.Basic.exec(conn, "EXPLAIN QUERY PLAN " <> sql, args)
+      assert {:ok, rows, _columns} = Exqlite.Basic.rows(result)
+
+      assert Enum.any?(rows, fn [_id, _parent, _unused, detail] ->
+               String.contains?(detail, "SEARCH entries USING INDEX entries_subject_idx") and
+                 String.contains?(detail, "subject=?")
+             end)
+    after
+      Exqlite.Basic.close(conn)
+    end
+  end
+
+  test "exact_many follows the disabled store behavior", %{project: project} do
+    assert :ok = Store.destroy(project)
+    assert [] = Store.exact_many(project, ["Foo.Bar"], [])
+    assert :ok = Store.enable(project)
+    assert {:ok, []} = Store.exact_many(project, ["Foo.Bar"], [])
+  end
+
+  test "exact_many propagates SQL failures", %{project: project} do
+    patch(Exqlite.Basic, :exec, fn _conn, _sql, _args -> {:error, :busy, nil} end)
+
+    assert {:error, :busy} = Store.exact_many(project, ["Foo.Bar"], [])
+  end
+
+  test "by_caller returns only matching occurrences using the caller index", %{project: project} do
+    first = %Entry{
+      id: 1,
+      block_id: :root,
+      path: "/core.ex",
+      caller: "Core.public/1",
+      subject: "Core.private/2",
+      type: {:function, :usage},
+      subtype: :reference,
+      range: %{start: 1, end: 2}
+    }
+
+    second = %{first | id: 2, subject: "Core.Piece.new/2", range: %{start: 3, end: 4}}
+    repeated = %{second | id: 3, block_id: 123, range: %{start: 5, end: 6}}
+    other_caller = %{first | id: 4, caller: "Core.public/2"}
+    other_path = %{first | id: 5, path: "/other/core.ex"}
+    no_caller = %{first | id: 6, caller: nil}
+    definition = %{first | id: 7, subtype: :definition}
+    other_type = %{first | id: 8, type: :module}
+
+    assert :ok =
+             Store.replace(project, [
+               first,
+               second,
+               repeated,
+               other_caller,
+               other_path,
+               no_caller,
+               definition,
+               other_type
+             ])
+
+    spy(Exqlite.Basic)
+
+    assert {:ok, matches} =
+             Store.by_caller(project, "Core.public/1", "/core.ex",
+               type: {:function, :usage},
+               subtype: :reference
+             )
+
+    assert [^first, ^second, ^repeated] = Enum.sort_by(matches, & &1.id)
+    assert_called(Exqlite.Basic.exec(_, sql, args), 1)
+
+    {:ok, conn} = Exqlite.Basic.open(Sqlite.database_path(project, runtime_versions()))
+
+    try do
+      result = Exqlite.Basic.exec(conn, "EXPLAIN QUERY PLAN " <> sql, args)
+      assert {:ok, rows, _columns} = Exqlite.Basic.rows(result)
+
+      assert Enum.any?(rows, fn [_id, _parent, _unused, detail] ->
+               String.contains?(detail, "SEARCH entries USING INDEX entries_caller_idx") and
+                 String.contains?(detail, "caller=? AND path=?")
+             end)
+    after
+      Exqlite.Basic.close(conn)
+    end
+
+    assert {:ok, matches} = Store.by_caller(project, "Core.public/1", "/core.ex")
+    assert [^first, ^second, ^repeated, ^definition, ^other_type] = Enum.sort_by(matches, & &1.id)
+    assert {:ok, []} = Store.by_caller(project, "Core.public", "/core.ex")
+    assert {:ok, []} = Store.by_caller(project, "Core.public/1", "/missing.ex")
+  end
+
+  test "by_caller follows store availability and propagates SQL failures", %{project: project} do
+    assert :ok = Store.destroy(project)
+    assert [] = Store.by_caller(project, "Core.public/1", "/core.ex")
+    assert :ok = Store.enable(project)
+    assert {:ok, []} = Store.by_caller(project, "Core.public/1", "/core.ex")
+
+    patch(Exqlite.Basic, :exec, fn _conn, _sql, _args -> {:error, :busy, nil} end)
+
+    assert {:error, :busy} = Store.by_caller(project, "Core.public/1", "/core.ex")
+  end
+
   test "updates replace entries for the same path", %{project: project} do
     path = "/path/to/file.ex"
 

--- a/apps/forge/lib/forge/ast/analysis.ex
+++ b/apps/forge/lib/forge/ast/analysis.ex
@@ -302,12 +302,13 @@ defmodule Forge.Ast.Analysis do
     {skip_leading_do(quoted), new_state}
   end
 
-  # defimpl Foo, for: SomeProtocol do
+  # defimpl Foo, for: Bar do ... end
+  # defimpl Foo, for: Bar, do: ...
   defp analyze_node(
          {:defimpl, _meta,
           [
             {:__aliases__, _, protocol_segments},
-            [{_for_keyword, {:__aliases__, _, for_segments}}] | _
+            [{{:__block__, _, [:for]}, {:__aliases__, _, for_segments}} | _] | _
           ]} = quoted,
          state
        ) do

--- a/apps/forge/lib/forge/search/indexer/entry.ex
+++ b/apps/forge/lib/forge/search/indexer/entry.ex
@@ -18,6 +18,7 @@ defmodule Forge.Search.Indexer.Entry do
           | {:function, function_type()}
 
   @type subject :: String.t()
+  @type caller :: String.t()
   @type entry_subtype :: :reference | :definition
   @type version :: String.t()
   @type entry_id :: pos_integer() | nil
@@ -36,6 +37,7 @@ defmodule Forge.Search.Indexer.Entry do
     :path,
     :range,
     :subject,
+    :caller,
     :subtype,
     :type,
     :metadata
@@ -44,6 +46,7 @@ defmodule Forge.Search.Indexer.Entry do
   @type t :: %__MODULE__{
           application: module(),
           subject: subject(),
+          caller: caller() | nil,
           block_id: block_id(),
           block_range: Forge.Document.Range.t() | nil,
           path: Path.t(),

--- a/apps/forge/lib/forge/search/indexer/source/block.ex
+++ b/apps/forge/lib/forge/search/indexer/source/block.ex
@@ -5,7 +5,7 @@ defmodule Forge.Search.Indexer.Source.Block do
 
   alias Forge.Identifier
 
-  defstruct [:starts_at, :ends_at, :id, :parent_id]
+  defstruct [:starts_at, :ends_at, :id, :parent_id, :caller]
 
   def root do
     %__MODULE__{id: :root}

--- a/apps/forge/test/forge/ast_test.exs
+++ b/apps/forge/test/forge/ast_test.exs
@@ -324,6 +324,44 @@ defmodule Forge.AstTest do
       ]
       assert %Analysis{} = analyze(code)
     end
+
+    test "creates an analysis with expanded aliases in a keyword-do implementation" do
+      code = ~q[
+        defmodule Outer do
+          alias Example.Action
+          alias Example.Record
+          defimpl Action, for: Record, do: (
+            |__MODULE__
+          )
+        end
+      ]
+
+      {position, document} = pop_cursor(code, as: :document)
+      analysis = Ast.analyze(document)
+      assert analysis.valid?
+      assert [scope | _] = Analysis.scopes_at(analysis, position)
+      assert scope.module == [:Example, :Action, :Example, :Record]
+
+      aliases = Analysis.Scope.alias_map(scope)
+      assert aliases[[:__MODULE__]].module == [:Example, :Action, :Example, :Record]
+      assert aliases[[:"@protocol"]].module == [:Example, :Action]
+      assert aliases[[:"@for"]].module == [:Example, :Record]
+    end
+
+    test "ends a keyword-do implementation scope before the next expression" do
+      code = ~q[
+        defmodule Outer do
+          defimpl Action, for: Atom, do: :ok; |__MODULE__
+        end
+      ]
+
+      {position, document} = pop_cursor(code, as: :document)
+      analysis = Ast.analyze(document)
+      assert analysis.valid?
+      assert [scope | _] = Analysis.scopes_at(analysis, position)
+      assert scope.module == [:Outer]
+      assert Analysis.Scope.alias_map(scope)[[:__MODULE__]].module == [:Outer]
+    end
   end
 
   describe "parser crash logging" do


### PR DESCRIPTION
Close #143 

Adds support for Call Hierarchy https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_prepareCallHierarchy

The bulk of this change is actually an update to the indexer so it tracks the caller for references, so we can resolve incoming/outgoing calls faster in the call hierarchy calls. The alternative is to scan a bunch of code when call hierarchy is requested, this is more or less what ElixirLS does, but since we have an index to make these lookups fast I think we should leverage it.

The actual implementation is in the last commit in this PR. I made a few decisions specific to Elixir for this feature:

- Callers can only be a named function, a module, or a file. I decided to ignore closures/anonymous functions, it seems a common practice in LSP implementations
- Functions can have multiple clauses, which are not really guaranteed to be continuous and can have all sorts of edge cases, so this implementation only considers the first function clause for the ranges
- While a module or a file can be callers for a function, the Prepare request will always return an empty result for them. They are not functions themselves and as such can not be called